### PR TITLE
Remove useless error checks

### DIFF
--- a/attack.go
+++ b/attack.go
@@ -166,15 +166,10 @@ func AttackCredentials(c Curler, targets []Stream, credentials Credentials, time
 		attackResults = append(attackResults, <-attacks)
 	}
 
-	found := 0
 	for _, result := range attackResults {
 		if result.CredentialsFound == true {
 			targets = replace(targets, result)
-			found++
 		}
-	}
-	if found == 0 {
-		return targets, errors.New("no credentials found")
 	}
 
 	return targets, nil
@@ -201,15 +196,10 @@ func AttackRoute(c Curler, targets []Stream, routes Routes, timeout time.Duratio
 		attackResults = append(attackResults, <-attacks)
 	}
 
-	found := 0
 	for _, result := range attackResults {
 		if result.RouteFound == true {
 			targets = replace(targets, result)
-			found++
 		}
-	}
-	if found == 0 {
-		return targets, errors.New("no routes found")
 	}
 
 	return targets, nil

--- a/attack_test.go
+++ b/attack_test.go
@@ -110,7 +110,6 @@ func TestAttackCredentials(t *testing.T) {
 			performErr: errors.New("dummy error"),
 
 			expectedStreams: fakeTargets,
-			expectedErrMsg:  "no credentials found",
 		},
 		// curl getinfo fails
 		{
@@ -121,19 +120,6 @@ func TestAttackCredentials(t *testing.T) {
 			getInfoErr: errors.New("dummy error"),
 
 			expectedStreams: fakeTargets,
-			expectedErrMsg:  "no credentials found",
-		},
-		// Credentials not found
-		{
-			targets:     fakeTargets,
-			credentials: fakeCredentials,
-			timeout:     1 * time.Millisecond,
-			log:         true,
-
-			status: 403,
-
-			expectedStreams: fakeTargets,
-			expectedErrMsg:  "no credentials found",
 		},
 		// Logging disabled
 		{
@@ -145,7 +131,17 @@ func TestAttackCredentials(t *testing.T) {
 			status: 403,
 
 			expectedStreams: fakeTargets,
-			expectedErrMsg:  "no credentials found",
+		},
+		// Logging enabled
+		{
+			targets:     fakeTargets,
+			credentials: fakeCredentials,
+			timeout:     1 * time.Millisecond,
+			log:         true,
+
+			status: 403,
+
+			expectedStreams: fakeTargets,
 		},
 	}
 	for i, test := range testCases {
@@ -272,7 +268,6 @@ func TestAttackRoute(t *testing.T) {
 			performErr: errors.New("dummy error"),
 
 			expectedStreams: fakeTargets,
-			expectedErrMsg:  "no routes found",
 		},
 		// curl getinfo fails
 		{
@@ -283,17 +278,6 @@ func TestAttackRoute(t *testing.T) {
 			getInfoErr: errors.New("dummy error"),
 
 			expectedStreams: fakeTargets,
-			expectedErrMsg:  "no routes found",
-		},
-		// Routes not found
-		{
-			targets: fakeTargets,
-			routes:  fakeRoutes,
-			timeout: 1 * time.Millisecond,
-			log:     true,
-
-			expectedStreams: fakeTargets,
-			expectedErrMsg:  "no routes found",
 		},
 		// Logs disabled
 		{
@@ -303,7 +287,15 @@ func TestAttackRoute(t *testing.T) {
 			log:     false,
 
 			expectedStreams: fakeTargets,
-			expectedErrMsg:  "no routes found",
+		},
+		// Logs enabled
+		{
+			targets: fakeTargets,
+			routes:  fakeRoutes,
+			timeout: 1 * time.Millisecond,
+			log:     true,
+
+			expectedStreams: fakeTargets,
 		},
 	}
 	for i, test := range testCases {


### PR DESCRIPTION
This PR removes the cases where the Attack methods were returning an error if they failed to attack any streams, as the responsibility to know whether or not it's an error belongs above this call.