### PR TITLE
Remove outdated dependencies

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,10 +38,6 @@
   name = "github.com/gernest/wow"
 
 [[constraint]]
-  name = "github.com/gorilla/websocket"
-  version = "1.2.0"
-
-[[constraint]]
   name = "github.com/pkg/errors"
   version = "0.8.0"
 
@@ -60,10 +56,6 @@
 [[constraint]]
   name = "gopkg.in/go-playground/validator.v9"
   version = "9.9.3"
-
-[[constraint]]
-  name = "gopkg.in/tylerb/graceful.v1"
-  version = "1.2.15"
 
 [prune]
   go-tests = true


### PR DESCRIPTION
Removes this annoying warning:

```
\Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  github.com/gorilla/websocket
  ✗  gopkg.in/tylerb/graceful.v1

However, these projects are not direct dependencies of the current project:
they are not imported in any .go files, nor are they in the 'required' list in
Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
these rules will have no effect.

Either import/require packages from these projects so that they become direct
dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
on these projects, if they happen to be transitive dependencies,
```