### PR TITLE
Update documentation on new dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,23 +76,16 @@ Only use this solution if for some reason using docker is not an option for you 
 
 ### Dependencies
 
-* `go`
-* `dep`
-
-#### Installing dep
-
-* OSX: `brew install dep` and `brew upgrade dep`
-* Others: Download the release package for your OS [here](https://github.com/golang/dep/releases)
+* `go` (> `1.10`)
 
 ### Steps to install
 
-Make sure you installed the dependencies mentionned above.
+Make sure you installed the dependencies mentionned above, and that you have Go modules enabled (`GO111MODULE=on`)
 
 1. `go get github.com/ullaakut/cameradar`
 2. `cd $GOPATH/src/github.com/ullaakut/cameradar`
-3. `dep ensure`
-4. `cd cameradar`
-5. `go install`
+3. `cd cameradar`
+4. `go install`
 
 The `cameradar` binary is now in your `$GOPATH/bin` ready to be used. See command line options [here](#command-line-options).
 

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,16 @@ module github.com/ullaakut/cameradar
 require (
 	github.com/Ullaakut/nmap v0.0.0-20190306183004-e38898a9bead // indirect
 	github.com/fatih/color v1.7.0 // indirect
-	github.com/gernest/wow v0.1.0 // indirect
+	github.com/gernest/wow v0.1.0
 	github.com/go-playground/locales v0.12.1 // indirect
 	github.com/go-playground/universal-translator v0.16.0 // indirect
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.6 // indirect
 	github.com/pkg/errors v0.8.1
-	github.com/spf13/viper v1.3.1 // indirect
-	github.com/ullaakut/disgo v0.3.0 // indirect
+	github.com/spf13/pflag v1.0.3
+	github.com/spf13/viper v1.3.1
+	github.com/ullaakut/disgo v0.3.0
 	github.com/ullaakut/go-curl v0.0.0-20190310175419-50acab4cef70
 	github.com/ullaakut/nmap v0.0.0-20190306183004-e38898a9bead
 	gopkg.in/go-playground/validator.v9 v9.27.0


### PR DESCRIPTION
This PR updates the documentation of the project on how to build the binary using `go build`/`go install`, with go modules instead of `dep`.

Fixes #194 