### PR TITLE
Add digest authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ You forgot the `-t` flag before `ullaakut/cameradar` in your command-line. This 
 
 Simply run `docker run -p 8554:8554 -e RTSP_USERNAME=admin -e RTSP_PASSWORD=12345 -e RTSP_PORT=8554 ullaakut/rtspatt` and then run cameradar and it should guess that the username is admin and the password is 12345. You can try this with any default constructor credentials (they can be found [here](dictionaries/credentials.json))
 
+> What authentication types does Cameradar support?
+
+Cameradar supports both basic and digest authentication.
+
 ## Examples
 
 > Running cameradar on your own machine to scan for default ports

--- a/attack.go
+++ b/attack.go
@@ -101,13 +101,7 @@ func DetectAuthMethods(c Curler, targets []Stream, timeout time.Duration, log bo
 	attacks := make(chan Stream)
 	defer close(attacks)
 
-	validate := v.New()
 	for i := range targets {
-		err := validate.Struct(targets[i])
-		if err != nil {
-			return targets, errors.Wrap(err, "invalid targets")
-		}
-
 		targets[i].AuthenticationType = detectAuthMethod(c, targets[i], timeout, log)
 	}
 

--- a/attack.go
+++ b/attack.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	curl "github.com/ullaakut/go-curl"
 	"github.com/pkg/errors"
+	curl "github.com/ullaakut/go-curl"
 	v "gopkg.in/go-playground/validator.v9"
 )
 
@@ -23,9 +23,174 @@ const (
 	rtspSetup    = 4
 )
 
+// ValidateStreams tries to setup the stream to validate whether or not it is available
+func ValidateStreams(c Curler, targets []Stream, timeout time.Duration, log bool) ([]Stream, error) {
+	for i := range targets {
+		targets[i].Available = validateStream(c, targets[i], timeout, log)
+	}
+
+	return targets, nil
+}
+
+// AttackCredentials attempts to guess the provided targets' credentials using the given
+// dictionary or the default dictionary if none was provided by the user.
+func AttackCredentials(c Curler, targets []Stream, credentials Credentials, timeout time.Duration, log bool) ([]Stream, error) {
+	attacks := make(chan Stream)
+	defer close(attacks)
+
+	validate := v.New()
+	for _, target := range targets {
+		err := validate.Struct(target)
+		if err != nil {
+			return targets, errors.Wrap(err, "invalid targets")
+		}
+
+		// TODO: Perf Improvement: Skip cameras with no auth type detected, and set their
+		// CredentialsFound value to true.
+
+		go attackCameraCredentials(c, target, credentials, attacks, timeout, log)
+	}
+
+	attackResults := []Stream{}
+	for range targets {
+		attackResults = append(attackResults, <-attacks)
+	}
+
+	for _, result := range attackResults {
+		if result.CredentialsFound {
+			targets = replace(targets, result)
+		}
+	}
+
+	return targets, nil
+}
+
+// AttackRoute attempts to guess the provided targets' streaming routes using the given
+// dictionary or the default dictionary if none was provided by the user.
+func AttackRoute(c Curler, targets []Stream, routes Routes, timeout time.Duration, log bool) ([]Stream, error) {
+	attacks := make(chan Stream)
+	defer close(attacks)
+
+	validate := v.New()
+	for _, target := range targets {
+		err := validate.Struct(target)
+		if err != nil {
+			return targets, errors.Wrap(err, "invalid targets")
+		}
+
+		go attackCameraRoute(c, target, routes, attacks, timeout, log)
+	}
+
+	attackResults := []Stream{}
+	for range targets {
+		attackResults = append(attackResults, <-attacks)
+	}
+
+	for _, result := range attackResults {
+		if result.RouteFound {
+			targets = replace(targets, result)
+		}
+	}
+
+	return targets, nil
+}
+
+// DetectAuthMethods attempts to guess the provided targets' authentication types, between
+// digest, basic auth or none at all.
+func DetectAuthMethods(c Curler, targets []Stream, timeout time.Duration, log bool) ([]Stream, error) {
+	attacks := make(chan Stream)
+	defer close(attacks)
+
+	validate := v.New()
+	for i := range targets {
+		err := validate.Struct(targets[i])
+		if err != nil {
+			return targets, errors.Wrap(err, "invalid targets")
+		}
+
+		targets[i].AuthenticationType = detectAuthMethod(c, targets[i], timeout, log)
+	}
+
+	return targets, nil
+}
+
+func attackCameraCredentials(c Curler, target Stream, credentials Credentials, resultsChan chan<- Stream, timeout time.Duration, log bool) {
+	for _, username := range credentials.Usernames {
+		for _, password := range credentials.Passwords {
+			ok := credAttack(c.Duphandle(), target, username, password, timeout, log)
+			if ok {
+				target.CredentialsFound = true
+				target.Username = username
+				target.Password = password
+				resultsChan <- target
+				return
+			}
+		}
+	}
+	target.CredentialsFound = false
+	resultsChan <- target
+}
+
+func attackCameraRoute(c Curler, target Stream, routes Routes, resultsChan chan<- Stream, timeout time.Duration, log bool) {
+	for _, route := range routes {
+		ok := routeAttack(c.Duphandle(), target, route, timeout, log)
+		if ok {
+			target.RouteFound = true
+			target.Route = route
+			resultsChan <- target
+			return
+		}
+	}
+	target.RouteFound = false
+	resultsChan <- target
+}
+
 // HACK: See https://stackoverflow.com/questions/3572397/lib-curl-in-c-disable-printing
 func doNotWrite([]uint8, interface{}) bool {
 	return true
+}
+
+func detectAuthMethod(c Curler, stream Stream, timeout time.Duration, enableLogs bool) int {
+	attackURL := fmt.Sprintf(
+		"rtsp://%s:%d/%s",
+		stream.Address,
+		stream.Port,
+		stream.Route,
+	)
+
+	if enableLogs {
+		// Debug logs when logs are enabled
+		c.Setopt(curl.OPT_VERBOSE, 1)
+	} else {
+		// Do not write sdp in stdout
+		c.Setopt(curl.OPT_WRITEFUNCTION, doNotWrite)
+	}
+
+	// Do not use signals (would break multithreading)
+	c.Setopt(curl.OPT_NOSIGNAL, 1)
+	// Do not send a body in the describe request
+	c.Setopt(curl.OPT_NOBODY, 1)
+	// Send a request to the URL of the stream we want to attack
+	c.Setopt(curl.OPT_URL, attackURL)
+	// Set the RTSP STREAM URI as the stream URL
+	c.Setopt(curl.OPT_RTSP_STREAM_URI, attackURL)
+	// 2 is CURL_RTSPREQ_DESCRIBE
+	c.Setopt(curl.OPT_RTSP_REQUEST, 2)
+	// Set custom timeout
+	c.Setopt(curl.OPT_TIMEOUT_MS, int(timeout/time.Millisecond))
+
+	// Perform the request
+	err := c.Perform()
+	if err != nil {
+		return -1
+	}
+
+	authType, err := c.Getinfo(curl.INFO_HTTPAUTH_AVAIL)
+	if err != nil {
+		return -1
+	}
+
+	return authType.(int)
 }
 
 func routeAttack(c Curler, stream Stream, route string, timeout time.Duration, enableLogs bool) bool {
@@ -45,6 +210,10 @@ func routeAttack(c Curler, stream Stream, route string, timeout time.Duration, e
 		// Do not write sdp in stdout
 		c.Setopt(curl.OPT_WRITEFUNCTION, doNotWrite)
 	}
+
+	// Set proper authentication type.
+	c.Setopt(curl.OPT_HTTPAUTH, stream.AuthenticationType)
+	c.Setopt(curl.OPT_USERPWD, fmt.Sprint(stream.Username, ":", stream.Password))
 
 	// Do not use signals (would break multithreading)
 	c.Setopt(curl.OPT_NOSIGNAL, 1)
@@ -97,6 +266,10 @@ func credAttack(c Curler, stream Stream, username string, password string, timeo
 		c.Setopt(curl.OPT_WRITEFUNCTION, doNotWrite)
 	}
 
+	// Set proper authentication type.
+	c.Setopt(curl.OPT_HTTPAUTH, stream.AuthenticationType)
+	c.Setopt(curl.OPT_USERPWD, fmt.Sprint(username, ":", password))
+
 	// Do not use signals (would break multithreading)
 	c.Setopt(curl.OPT_NOSIGNAL, 1)
 	// Do not send a body in the describe request
@@ -148,6 +321,10 @@ func validateStream(c Curler, stream Stream, timeout time.Duration, enableLogs b
 		c.Setopt(curl.OPT_WRITEFUNCTION, doNotWrite)
 	}
 
+	// Set proper authentication type.
+	c.Setopt(curl.OPT_HTTPAUTH, stream.AuthenticationType)
+	c.Setopt(curl.OPT_USERPWD, fmt.Sprint(stream.Username, ":", stream.Password))
+
 	// Do not use signals (would break multithreading)
 	c.Setopt(curl.OPT_NOSIGNAL, 1)
 	// Do not send a body in the describe request
@@ -180,104 +357,4 @@ func validateStream(c Curler, stream Stream, timeout time.Duration, enableLogs b
 		return true
 	}
 	return false
-}
-
-// ValidateStreams tries to setup the stream to validate whether or not it is available
-func ValidateStreams(c Curler, targets []Stream, timeout time.Duration, log bool) ([]Stream, error) {
-	for idx, target := range targets {
-		targets[idx].Available = validateStream(c, target, timeout, log)
-	}
-
-	return targets, nil
-}
-
-func attackCameraCredentials(c Curler, target Stream, credentials Credentials, resultsChan chan<- Stream, timeout time.Duration, log bool) {
-	for _, username := range credentials.Usernames {
-		for _, password := range credentials.Passwords {
-			ok := credAttack(c.Duphandle(), target, username, password, timeout, log)
-			if ok {
-				target.CredentialsFound = true
-				target.Username = username
-				target.Password = password
-				resultsChan <- target
-				return
-			}
-		}
-	}
-	target.CredentialsFound = false
-	resultsChan <- target
-}
-
-func attackCameraRoute(c Curler, target Stream, routes Routes, resultsChan chan<- Stream, timeout time.Duration, log bool) {
-	for _, route := range routes {
-		ok := routeAttack(c.Duphandle(), target, route, timeout, log)
-		if ok {
-			target.RouteFound = true
-			target.Route = route
-			resultsChan <- target
-			return
-		}
-	}
-	target.RouteFound = false
-	resultsChan <- target
-}
-
-// AttackCredentials attempts to guess the provided targets' credentials using the given
-// dictionary or the default dictionary if none was provided by the user.
-func AttackCredentials(c Curler, targets []Stream, credentials Credentials, timeout time.Duration, log bool) ([]Stream, error) {
-	attacks := make(chan Stream)
-	defer close(attacks)
-
-	validate := v.New()
-	for _, target := range targets {
-		err := validate.Struct(target)
-		if err != nil {
-			return targets, errors.Wrap(err, "invalid targets")
-		}
-
-		go attackCameraCredentials(c, target, credentials, attacks, timeout, log)
-	}
-
-	attackResults := []Stream{}
-	for range targets {
-		attackResults = append(attackResults, <-attacks)
-	}
-
-	for _, result := range attackResults {
-		if result.CredentialsFound {
-			targets = replace(targets, result)
-		}
-	}
-
-	return targets, nil
-}
-
-// AttackRoute attempts to guess the provided targets' streaming routes using the given
-// dictionary or the default dictionary if none was provided by the user.
-func AttackRoute(c Curler, targets []Stream, routes Routes, timeout time.Duration, log bool) ([]Stream, error) {
-	attacks := make(chan Stream)
-	defer close(attacks)
-
-	validate := v.New()
-	for _, target := range targets {
-		err := validate.Struct(target)
-		if err != nil {
-			return targets, errors.Wrap(err, "invalid targets")
-		}
-
-		go attackCameraRoute(c, target, routes, attacks, timeout, log)
-	}
-
-	attackResults := []Stream{}
-	for range targets {
-		attackResults = append(attackResults, <-attacks)
-	}
-
-	for _, result := range attackResults {
-		if result.RouteFound {
-			targets = replace(targets, result)
-		}
-	}
-
-	return targets, nil
 }

--- a/attack_test.go
+++ b/attack_test.go
@@ -2,14 +2,12 @@ package cmrdr
 
 import (
 	"errors"
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
-	curl "github.com/ullaakut/go-curl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	curl "github.com/ullaakut/go-curl"
 )
 
 type CurlerMock struct {
@@ -163,14 +161,12 @@ func TestAttackCredentials(t *testing.T) {
 
 		if len(test.expectedErrMsg) > 0 {
 			if err == nil {
-				fmt.Printf("unexpected success in AttackCredentials test, iteration %d. expected error: %s\n", i, test.expectedErrMsg)
-				os.Exit(1)
+				t.Errorf("unexpected success in AttackCredentials test, iteration %d. expected error: %s\n", i, test.expectedErrMsg)
 			}
 			assert.Contains(t, err.Error(), test.expectedErrMsg, "wrong error message")
 		} else {
 			if err != nil {
-				fmt.Printf("unexpected error in AttackCredentials test, iteration %d: %v\n", i, err)
-				os.Exit(1)
+				t.Errorf("unexpected error in AttackCredentials test, iteration %d: %v\n", i, err)
 			}
 			for _, stream := range test.expectedStreams {
 				foundStream := false
@@ -318,15 +314,13 @@ func TestAttackRoute(t *testing.T) {
 
 		if len(test.expectedErrMsg) > 0 {
 			if err == nil {
-				fmt.Printf("unexpected success in AttackRoute test, iteration %d. expected error: %s\n", i, test.expectedErrMsg)
-				os.Exit(1)
+				t.Errorf("unexpected success in AttackRoute test, iteration %d. expected error: %s\n", i, test.expectedErrMsg)
 			}
 
 			assert.Contains(t, err.Error(), test.expectedErrMsg, "wrong error message")
 		} else {
 			if err != nil {
-				fmt.Printf("unexpected error in AttackRoute test, iteration %d: %v\n", i, err)
-				os.Exit(1)
+				t.Errorf("unexpected error in AttackRoute test, iteration %d: %v\n", i, err)
 			}
 
 			for _, stream := range test.expectedStreams {
@@ -486,15 +480,130 @@ func TestValidateStreams(t *testing.T) {
 
 			if len(tC.expectedErrMsg) > 0 {
 				if err == nil {
-					fmt.Printf("unexpected success in ValidateStream test, iteration %d. expected error: %s\n", i, tC.expectedErrMsg)
-					os.Exit(1)
+					t.Errorf("unexpected success in ValidateStream test, iteration %d. expected error: %s\n", i, tC.expectedErrMsg)
 				}
 
 				assert.Contains(t, err.Error(), tC.expectedErrMsg, "wrong error message")
 			} else {
 				if err != nil {
-					fmt.Printf("unexpected error in ValidateStream test, iteration %d: %v\n", i, err)
-					os.Exit(1)
+					t.Errorf("unexpected error in ValidateStream test, iteration %d: %v\n", i, err)
+				}
+
+				for _, stream := range tC.expectedStreams {
+					foundStream := false
+					for _, result := range results {
+						if result.Address == stream.Address && result.Device == stream.Device && result.Port == stream.Port {
+							foundStream = true
+						}
+					}
+
+					assert.Equal(t, true, foundStream, "wrong streams parsed")
+				}
+			}
+
+			assert.Equal(t, len(tC.expectedStreams), len(results), "wrong streams parsed")
+
+			curlerMock.AssertExpectations(t)
+		})
+	}
+}
+
+func TestDetectAuthenticationType(t *testing.T) {
+	validStream1 := Stream{
+		Device:    "fakeDevice",
+		Address:   "fakeAddress",
+		Port:      1337,
+		Available: true,
+	}
+
+	validStream2 := Stream{
+		Device:    "fakeDevice",
+		Address:   "differentFakeAddress",
+		Port:      1337,
+		Available: true,
+	}
+
+	fakeTargets := []Stream{validStream1, validStream2}
+
+	testCases := []struct {
+		desc string
+
+		targets []Stream
+		timeout time.Duration
+		log     bool
+
+		status int
+
+		performErr error
+		getInfoErr error
+
+		expectedStreams []Stream
+		expectedErrMsg  string
+	}{
+		// curl getinfo fails
+		{
+			desc: "curl getinfo fails",
+
+			targets: fakeTargets,
+			timeout: 1 * time.Millisecond,
+
+			getInfoErr: errors.New("dummy error"),
+
+			expectedStreams: fakeTargets,
+		},
+		// curl perform fails
+		{
+			desc: "curl perform fails",
+
+			targets: fakeTargets,
+			timeout: 1 * time.Millisecond,
+
+			performErr: errors.New("dummy error"),
+
+			expectedStreams: fakeTargets,
+		},
+		// Logs disabled
+		{
+			desc: "logs disabled",
+
+			targets: fakeTargets,
+			timeout: 1 * time.Millisecond,
+			log:     false,
+
+			expectedStreams: fakeTargets,
+		},
+		// Logs enabled
+		{
+			desc: "logs enabled",
+
+			targets: fakeTargets,
+			timeout: 1 * time.Millisecond,
+			log:     true,
+
+			expectedStreams: fakeTargets,
+		},
+	}
+	for i, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			curlerMock := &CurlerMock{}
+
+			curlerMock.On("Setopt", mock.Anything, mock.Anything).Return(nil)
+			curlerMock.On("Perform").Return(tC.performErr)
+			if tC.performErr == nil {
+				curlerMock.On("Getinfo", mock.Anything).Return(tC.status, tC.getInfoErr)
+			}
+
+			results, err := DetectAuthMethods(curlerMock, tC.targets, tC.timeout, tC.log)
+
+			if len(tC.expectedErrMsg) > 0 {
+				if err == nil {
+					t.Errorf("unexpected success in DetectAuthMethods test, iteration %d. expected error: %s\n", i, tC.expectedErrMsg)
+				}
+
+				assert.Contains(t, err.Error(), tC.expectedErrMsg, "wrong error message")
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error in DetectAuthMethods test, iteration %d: %v\n", i, err)
 				}
 
 				for _, stream := range tC.expectedStreams {

--- a/cameradar/cameradar.go
+++ b/cameradar/cameradar.go
@@ -130,6 +130,9 @@ func main() {
 		printErr(term, err)
 	}
 
+	updateSpinner(w, "Found "+fmt.Sprint(len(streams))+" streams. Detecting their authentication methods...", options.EnableLogs)
+	streams, err = cmrdr.DetectAuthMethods(c, streams, time.Duration(options.Timeout)*time.Millisecond, options.EnableLogs)
+
 	updateSpinner(w, "Found "+fmt.Sprint(len(streams))+" streams. Attacking their credentials...", options.EnableLogs)
 	streams, err = cmrdr.AttackCredentials(c, streams, credentials, time.Duration(options.Timeout)*time.Millisecond, options.EnableLogs)
 	if err != nil && len(streams) > 0 {
@@ -163,47 +166,61 @@ func main() {
 
 func prettyPrint(term *log.Terminal, streams []cmrdr.Stream) {
 	success := 0
-	if len(streams) > 0 {
-		for _, stream := range streams {
-			if stream.CredentialsFound && stream.RouteFound && stream.Available {
-				term.Infof("%s\tDevice RTSP URL:\t%s\n", style.Success(style.SymbolRightTriangle), style.Link(cmrdr.GetCameraRTSPURL(stream)))
-				success++
-			} else {
-				term.Infof("%s\tAdmin panel URL:\t%s You can use this URL to try attacking the camera's admin panel instead.\n", style.Failure(style.SymbolCross), style.Link(cmrdr.GetCameraAdminPanelURL(stream)))
-			}
-
-			term.Infof("\tDevice model:\t\t%s\n\n", stream.Device)
-
-			if stream.Available {
-				term.Infof("\tAvailable:\t\t%s\n", style.Success(style.SymbolCheck))
-			} else {
-				term.Infof("\tAvailable:\t\t%s\n", style.Failure(style.SymbolCross))
-			}
-
-			term.Infof("\tIP address:\t\t%s\n", stream.Address)
-			term.Infof("\tRTSP port:\t\t%d\n", stream.Port)
-			if stream.CredentialsFound {
-				term.Infof("\tUsername:\t\t%s\n", style.Success(stream.Username))
-				term.Infof("\tPassword:\t\t%s\n", style.Success(stream.Password))
-			} else {
-				term.Infof("\tUsername:\t\t%s\n", style.Failure("not found"))
-				term.Infof("\tPassword:\t\t%s\n", style.Failure("not found"))
-			}
-			if stream.RouteFound {
-				term.Infof("\tRTSP route:\t\t%s\n\n\n", style.Success("/"+stream.Route))
-			} else {
-				term.Infof("\tRTSP route:\t\t%s\n\n\n", style.Failure("not found"))
-			}
-		}
-		if success > 1 {
-			term.Infof("%s Successful attack: %s devices were accessed", style.Success(style.SymbolCheck), style.Success(len(streams)))
-		} else if success == 1 {
-			term.Infof("%s Successful attack: %s device was accessed", style.Success(style.SymbolCheck), style.Success(len(streams)))
-		} else {
-			term.Infof("%s Streams were found but none were accessed. They are most likely configured with secure credentials and routes. You can try adding entries to the dictionary or generating your own in order to attempt a bruteforce attack on the cameras.\n", style.Failure("\xE2\x9C\x96"))
-		}
-	} else {
+	if len(streams) == 0 {
 		term.Infof("%s No streams were found. Please make sure that your target is on an accessible network.\n", style.Failure(style.SymbolCross))
+	}
+
+	for _, stream := range streams {
+		if stream.CredentialsFound && stream.RouteFound && stream.Available {
+			term.Infof("%s\tDevice RTSP URL:\t%s\n", style.Success(style.SymbolRightTriangle), style.Link(cmrdr.GetCameraRTSPURL(stream)))
+			success++
+		} else {
+			term.Infof("%s\tAdmin panel URL:\t%s You can use this URL to try attacking the camera's admin panel instead.\n", style.Failure(style.SymbolCross), style.Link(cmrdr.GetCameraAdminPanelURL(stream)))
+		}
+
+		if len(stream.Device) > 0 {
+			term.Infof("\tDevice model:\t\t%s\n\n", stream.Device)
+		}
+
+		if stream.Available {
+			term.Infof("\tAvailable:\t\t%s\n", style.Success(style.SymbolCheck))
+		} else {
+			term.Infof("\tAvailable:\t\t%s\n", style.Failure(style.SymbolCross))
+		}
+
+		term.Infof("\tIP address:\t\t%s\n", stream.Address)
+		term.Infof("\tRTSP port:\t\t%d\n", stream.Port)
+
+		switch stream.AuthenticationType {
+		case curl.AUTH_NONE:
+			term.Infoln("\tThis camera does not require authentication")
+		case curl.AUTH_BASIC:
+			term.Infoln("\tAuth type:\t\tbasic")
+		case curl.AUTH_DIGEST:
+			term.Infoln("\tAuth type:\t\tdigest")
+		}
+
+		if stream.CredentialsFound {
+			term.Infof("\tUsername:\t\t%s\n", style.Success(stream.Username))
+			term.Infof("\tPassword:\t\t%s\n", style.Success(stream.Password))
+		} else {
+			term.Infof("\tUsername:\t\t%s\n", style.Failure("not found"))
+			term.Infof("\tPassword:\t\t%s\n", style.Failure("not found"))
+		}
+
+		if stream.RouteFound {
+			term.Infof("\tRTSP route:\t\t%s\n\n\n", style.Success("/"+stream.Route))
+		} else {
+			term.Infof("\tRTSP route:\t\t%s\n\n\n", style.Failure("not found"))
+		}
+	}
+
+	if success > 1 {
+		term.Infof("%s Successful attack: %s devices were accessed", style.Success(style.SymbolCheck), style.Success(len(streams)))
+	} else if success == 1 {
+		term.Infof("%s Successful attack: %s device was accessed", style.Success(style.SymbolCheck), style.Success(len(streams)))
+	} else {
+		term.Infof("%s Streams were found but none were accessed. They are most likely configured with secure credentials and routes. You can try adding entries to the dictionary or generating your own in order to attempt a bruteforce attack on the cameras.\n", style.Failure("\xE2\x9C\x96"))
 	}
 }
 

--- a/models.go
+++ b/models.go
@@ -14,6 +14,8 @@ type Stream struct {
 	CredentialsFound bool `json:"credentials_found"`
 	RouteFound       bool `json:"route_found"`
 	Available        bool `json:"available"`
+
+	AuthenticationType int `json:"authentication_type"`
 }
 
 // Credentials is a map of credentials


### PR DESCRIPTION
## Goal of this PR

This PR adds automatic authentication type detection and adds support for the digest authentication type. It also slightly updates the attack summary to integrate those new features.

Fixes #199 

## How to test it

* `docker run --rm
       -e RTSP_PASSWORD="admin"
       -e RTSP_AUTHENTICATION_METHOD="basic"
       -e RTSP_USERNAME="admin"
       -p 8554:8554
       ullaakut/rtspatt`
* `docker run --net=host -t cameradar -t localhost`
* Cameradar should successfully access the camera and display its authentication type as basic
* `docker run --rm
       -e RTSP_PASSWORD="admin"
       -e RTSP_AUTHENTICATION_METHOD="digest"
       -e RTSP_USERNAME="admin"
       -p 8554:8554
       ullaakut/rtspatt`
* `docker run --net=host -t cameradar -t localhost`
* Cameradar should successfully access the camera and display its authentication type as digest
* `docker run --rm
       -p 8554:8554
       ullaakut/rtspatt`
* `docker run --net=host -t cameradar -t localhost`
* Cameradar should successfully access the camera and show that it does not require authentication

## TODO

* Add unit tests
* Add default aiphone camera credentials

## Screenshots

<img width="1031" alt="Screenshot 2019-05-21 at 10 38 16 AM" src="https://user-images.githubusercontent.com/6976628/58083113-ab523080-7bb8-11e9-8809-a6927275242f.png">
<img width="1031" alt="Screenshot 2019-05-21 at 10 38 38 AM" src="https://user-images.githubusercontent.com/6976628/58083115-abeac700-7bb8-11e9-8c85-ac90e722c541.png">
