### PR TITLE
Improve documentation and add warning when no gopath

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,12 +206,13 @@ Your image will be called `cameradar` and NOT `ullaakut/cameradar`.
 
 #### Go build
 
-Make sure you installed the [dependencies](#dependencies), and that you have Go modules enabled (`GO111MODULE=on`)
+Make sure you installed the [dependencies](#dependencies), **and that you have Go modules enabled (`GO111MODULE=on`)**.
 
-1. `go get github.com/ullaakut/cameradar`
-2. `cd $GOPATH/src/github.com/ullaakut/cameradar`
-3. `cd cameradar`
-4. `go build`
+1. `export GO111MODULE=on` (unless it's already on)
+2. `go get github.com/ullaakut/cameradar`
+3. `cd $GOPATH/src/github.com/ullaakut/cameradar`
+4. `cd cmd/cameradar`
+5. `go build`
 
 The cameradar binary is now in the root of the directory.
 

--- a/scanner.go
+++ b/scanner.go
@@ -7,7 +7,13 @@ import (
 	"time"
 
 	"github.com/ullaakut/disgo"
+	"github.com/ullaakut/disgo/style"
 	curl "github.com/ullaakut/go-curl"
+)
+
+const (
+	defaultCredentialDictionaryPath = "<GOPATH>/src/github.com/ullaakut/cameradar/dictionaries/credentials.json"
+	defaultRouteDictionaryPath      = "<GOPATH>/src/github.com/ullaakut/cameradar/dictionaries/routes"
 )
 
 // Scanner represents a cameradar scanner. It scans a network and
@@ -43,8 +49,8 @@ func New(options ...func(*Scanner)) (*Scanner, error) {
 
 	scanner := &Scanner{
 		curl:                     &Curl{CURL: handle},
-		credentialDictionaryPath: "<GOPATH>/src/github.com/ullaakut/cameradar/dictionaries/credentials.json",
-		routeDictionaryPath:      "<GOPATH>/src/github.com/ullaakut/cameradar/dictionaries/routes",
+		credentialDictionaryPath: defaultCredentialDictionaryPath,
+		routeDictionaryPath:      defaultRouteDictionaryPath,
 	}
 
 	for _, option := range options {
@@ -52,6 +58,10 @@ func New(options ...func(*Scanner)) (*Scanner, error) {
 	}
 
 	gopath := os.Getenv("GOPATH")
+	if gopath == "" && scanner.credentialDictionaryPath == defaultCredentialDictionaryPath && scanner.routeDictionaryPath == defaultRouteDictionaryPath {
+		disgo.Errorln(style.Failure("No $GOPATH was found.\nDictionaries may not be loaded properly, please set your $GOPATH to use the default dictionaries."))
+	}
+
 	scanner.credentialDictionaryPath = strings.Replace(scanner.credentialDictionaryPath, "<GOPATH>", gopath, 1)
 	scanner.routeDictionaryPath = strings.Replace(scanner.routeDictionaryPath, "<GOPATH>", gopath, 1)
 

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -3,6 +3,7 @@ package cameradar
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -77,21 +78,34 @@ func TestNew(t *testing.T) {
 
 			expectedErr: true,
 		},
+		{
+			description: "gopath not set and default dicts",
+
+			customCredentials: defaultCredentialDictionaryPath,
+			customRoutes:      defaultRouteDictionaryPath,
+
+			expectedErr: true,
+		},
 	}
+
+	// Temporarily empty the gopath for testing purposes.
+	defer os.Setenv("GOPATH", os.Getenv("GOPATH"))
 
 	for i, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			os.Setenv("GOPATH", "")
+
 			if test.loadTargetsFail {
 				test.targets = []string{generateTmpFileName(i, "targets")}
 				ioutil.WriteFile(test.targets[0], []byte(`0.0.0.0`), 0000)
 			}
 
-			if !test.loadCredsFail {
+			if !test.loadCredsFail && test.customCredentials == "" {
 				test.customCredentials = generateTmpFileName(i, "creds")
 				ioutil.WriteFile(test.customCredentials, []byte(`{"usernames":["admin"],"passwords":["admin"]}`), 0644)
 			}
 
-			if !test.loadRoutesFail {
+			if !test.loadRoutesFail && test.customRoutes == "" {
 				test.customRoutes = generateTmpFileName(i, "routes")
 				ioutil.WriteFile(test.customRoutes, []byte(`live.sdp`), 0644)
 			}


### PR DESCRIPTION
Fixes #218 

Adds a warning when no GOPATH while using default dictionaries
Updates manual install documentation
Emphasizes the need for go modules to be enabled