### PR TITLE
Change curl errors from debug to error level

### DIFF
--- a/attack.go
+++ b/attack.go
@@ -197,13 +197,13 @@ func (s *Scanner) detectAuthMethod(stream Stream) int {
 	// Perform the request.
 	err := c.Perform()
 	if err != nil {
-		s.term.Debugf("Perform failed: %v", err)
+		s.term.Errorf("Perform failed: %v", err)
 		return -1
 	}
 
 	authType, err := c.Getinfo(curl.INFO_HTTPAUTH_AVAIL)
 	if err != nil {
-		s.term.Debugf("Getinfo failed: %v", err)
+		s.term.Errorf("Getinfo failed: %v", err)
 		return -1
 	}
 
@@ -242,14 +242,14 @@ func (s *Scanner) routeAttack(stream Stream, route string) bool {
 	// Perform the request.
 	err := c.Perform()
 	if err != nil {
-		s.term.Debugf("Perform failed: %v", err)
+		s.term.Errorf("Perform failed: %v", err)
 		return false
 	}
 
 	// Get return code for the request.
 	rc, err := c.Getinfo(curl.INFO_RESPONSE_CODE)
 	if err != nil {
-		s.term.Debugf("Getinfo failed: %v", err)
+		s.term.Errorf("Getinfo failed: %v", err)
 		return false
 	}
 
@@ -292,14 +292,14 @@ func (s *Scanner) credAttack(stream Stream, username string, password string) bo
 	// Perform the request.
 	err := c.Perform()
 	if err != nil {
-		s.term.Debugf("Perform failed: %v", err)
+		s.term.Errorf("Perform failed: %v", err)
 		return false
 	}
 
 	// Get return code for the request.
 	rc, err := c.Getinfo(curl.INFO_RESPONSE_CODE)
 	if err != nil {
-		s.term.Debugf("Getinfo failed: %v", err)
+		s.term.Errorf("Getinfo failed: %v", err)
 		return false
 	}
 
@@ -345,14 +345,14 @@ func (s *Scanner) validateStream(stream Stream) bool {
 	// Perform the request.
 	err := c.Perform()
 	if err != nil {
-		s.term.Debugf("Perform failed: %v", err)
+		s.term.Errorf("Perform failed: %v", err)
 		return false
 	}
 
 	// Get return code for the request.
 	rc, err := c.Getinfo(curl.INFO_RESPONSE_CODE)
 	if err != nil {
-		s.term.Debugf("Getinfo failed: %v", err)
+		s.term.Errorf("Getinfo failed: %v", err)
 		return false
 	}
 


### PR DESCRIPTION
## Goal of this PR

Fixes #222 

Improves error handling in cases of timeouts, which should improve the UX when attacking slow/unstable networks remotely.

## Screenshots

<img width="956" alt="Screenshot 2019-06-15 at 7 59 43 AM" src="https://user-images.githubusercontent.com/6976628/59547726-b728dc80-8f43-11e9-862f-1e1c74ed883c.png">

## How to test it

* `docker run --rm -e RTSP_PASSWORD="admin" -e RTSP_AUTHENTICATION_METHOD="basic" -e RTSP_USERNAME="admin" -p 8554:8554 ullaakut/rtspatt`
* `docker run --net=host -t ullaakut/cameradar -t localhost`
* After the camera has been discovered, during the attack phase, kill the RTSPATT container so that the requests timeout/fail
* Ensure that the logs are now properly displayed as errors even without verbose mode enabled