### PR TITLE
Use os.ExpandEnv for injecting gopath in dict path

### DIFF
--- a/cmd/cameradar/cameradar.go
+++ b/cmd/cameradar/cameradar.go
@@ -20,8 +20,8 @@ func parseArguments() error {
 
 	pflag.StringSliceP("targets", "t", []string{}, "The targets on which to scan for open RTSP streams - required (ex: 172.16.100.0/24)")
 	pflag.StringSliceP("ports", "p", []string{"554", "5554", "8554"}, "The ports on which to search for RTSP streams")
-	pflag.StringP("custom-routes", "r", "<GOPATH>/src/github.com/ullaakut/cameradar/dictionaries/routes", "The path on which to load a custom routes dictionary")
-	pflag.StringP("custom-credentials", "c", "<GOPATH>/src/github.com/ullaakut/cameradar/dictionaries/credentials.json", "The path on which to load a custom credentials JSON dictionary")
+	pflag.StringP("custom-routes", "r", "${GOPATH}/src/github.com/ullaakut/cameradar/dictionaries/routes", "The path on which to load a custom routes dictionary")
+	pflag.StringP("custom-credentials", "c", "${GOPATH}/src/github.com/ullaakut/cameradar/dictionaries/credentials.json", "The path on which to load a custom credentials JSON dictionary")
 	pflag.IntP("speed", "s", 4, "The nmap speed preset to use for discovery")
 	pflag.DurationP("timeout", "T", 2*time.Second, "The timeout in miliseconds to use for attack attempts")
 	pflag.BoolP("debug", "d", true, "Enable the debug logs")

--- a/scanner.go
+++ b/scanner.go
@@ -3,7 +3,6 @@ package cameradar
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/ullaakut/disgo"
@@ -12,8 +11,8 @@ import (
 )
 
 const (
-	defaultCredentialDictionaryPath = "<GOPATH>/src/github.com/ullaakut/cameradar/dictionaries/credentials.json"
-	defaultRouteDictionaryPath      = "<GOPATH>/src/github.com/ullaakut/cameradar/dictionaries/routes"
+	defaultCredentialDictionaryPath = "${GOPATH}/src/github.com/ullaakut/cameradar/dictionaries/credentials.json"
+	defaultRouteDictionaryPath      = "${GOPATH}/src/github.com/ullaakut/cameradar/dictionaries/routes"
 )
 
 // Scanner represents a cameradar scanner. It scans a network and
@@ -62,8 +61,8 @@ func New(options ...func(*Scanner)) (*Scanner, error) {
 		disgo.Errorln(style.Failure("No $GOPATH was found.\nDictionaries may not be loaded properly, please set your $GOPATH to use the default dictionaries."))
 	}
 
-	scanner.credentialDictionaryPath = strings.Replace(scanner.credentialDictionaryPath, "<GOPATH>", gopath, 1)
-	scanner.routeDictionaryPath = strings.Replace(scanner.routeDictionaryPath, "<GOPATH>", gopath, 1)
+	scanner.credentialDictionaryPath = os.ExpandEnv(scanner.credentialDictionaryPath)
+	scanner.routeDictionaryPath = os.ExpandEnv(scanner.routeDictionaryPath)
 
 	scanner.term = disgo.NewTerminal(
 		disgo.WithDebug(scanner.debug),


### PR DESCRIPTION
## Goal of this PR

Fixes #217 

## How to test it

* `go build cmd/cameradar/cameradar.go`
* `cameradar -t localhost`
* You should see a log displaying the proper path when loading the credentials

## Example

<img width="650" alt="Screenshot 2019-06-15 at 6 31 33 PM" src="https://user-images.githubusercontent.com/6976628/59553865-d3586800-8f9b-11e9-914c-19f97357525b.png">
