### PR TITLE
Fix goreleaser deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ script:
 - cat camera_basic_logs.txt
 - cat logs.txt
 - grep "Successful attack" logs.txt || exit 1
+- git clean -fd
 
 after_success:
 # You'll need to run `snapcraft export-login snap.login` and


### PR DESCRIPTION
## Goal of this PR

Fixes goreleaser deployments failing due to a dirty state in git after the end to end tests leave log files.

## How to test it

* Release the `4.1.1`