### PR TITLE
Fix scan interval option

### DIFF
--- a/attack.go
+++ b/attack.go
@@ -79,7 +79,6 @@ func (s *Scanner) AttackCredentials(targets []Stream) []Stream {
 		// TODO: Perf Improvement: Skip cameras with no auth type detected, and set their
 		// CredentialsFound value to true.
 		go s.attackCameraCredentials(targets[i], resChan)
-		time.Sleep(s.attackInterval)
 	}
 
 	attackResults := []Stream{}
@@ -105,7 +104,6 @@ func (s *Scanner) AttackRoute(targets []Stream) []Stream {
 
 	for i := range targets {
 		go s.attackCameraRoute(targets[i], resChan)
-		time.Sleep(s.attackInterval)
 	}
 
 	attackResults := []Stream{}
@@ -157,6 +155,7 @@ func (s *Scanner) attackCameraCredentials(target Stream, resChan chan<- Stream) 
 				resChan <- target
 				return
 			}
+			time.Sleep(s.attackInterval)
 		}
 	}
 
@@ -173,6 +172,7 @@ func (s *Scanner) attackCameraRoute(target Stream, resChan chan<- Stream) {
 			resChan <- target
 			return
 		}
+		time.Sleep(s.attackInterval)
 	}
 
 	target.RouteFound = false


### PR DESCRIPTION
## Goal of this PR

This PR fixes the scan interval option introduced by the PR #245 by placing the sleep delays between credentials/route guess attempt instead of between the camera on each attack.

As seen on this screenshot, the delay is now properly applied between each request.

<img width="952" alt="Screenshot 2019-11-12 at 8 30 57 AM" src="https://user-images.githubusercontent.com/6976628/68651039-c4fc8100-0526-11ea-9019-6a730ac502fb.png">
