### PR TITLE
Add libcurl requirement to build from binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Only use this solution if for some reason using docker is not an option for you 
 ### Dependencies
 
 * `go` (> `1.10`)
+* `libcurl` development library
+    * For apt users: `apt install libcurl4-openssl-dev`
 
 ### Steps to install
 


### PR DESCRIPTION
## Goal of this PR

Part of #248 

This PR documents the dependency on libcurl for building the binary.