### PR TITLE
Use older curl version to fix digest authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,14 @@ RUN go build -o cameradar
 # Final stage
 FROM alpine
 
+# Necessary to install curl v7.64.0-r3.
+# Fix for https://github.com/Ullaakut/cameradar/issues/247
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' >> /etc/apk/repositories
+
 RUN apk --update add --no-cache nmap \
     nmap-nselibs \
     nmap-scripts \
-    curl-dev
+    curl-dev==7.64.0-r3
 
 WORKDIR /app/cameradar
 COPY --from=build-env /go/src/github.com/Ullaakut/cameradar/dictionaries/ /app/dictionaries/

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Only use this solution if for some reason using docker is not an option for you 
 ### Dependencies
 
 * `go` (> `1.10`)
-* `libcurl` development library
+* `libcurl` development library (**[version has to be <7.66.0](https://github.com/Ullaakut/cameradar/issues/247)**)
     * For apt users: `apt install libcurl4-openssl-dev`
 
 ### Steps to install

--- a/attack.go
+++ b/attack.go
@@ -191,17 +191,18 @@ func (s *Scanner) detectAuthMethod(stream Stream) int {
 
 	s.setCurlOptions(c)
 
+	_ = c.Setopt(curl.OPT_VERBOSE, 1)
+
 	// Send a request to the URL of the stream we want to attack.
 	_ = c.Setopt(curl.OPT_URL, attackURL)
 	// Set the RTSP STREAM URI as the stream URL.
 	_ = c.Setopt(curl.OPT_RTSP_STREAM_URI, attackURL)
-	// 2 is CURL_RTSPREQ_DESCRIBE.
-	_ = c.Setopt(curl.OPT_RTSP_REQUEST, 2)
+	_ = c.Setopt(curl.OPT_RTSP_REQUEST, rtspDescribe)
 
 	// Perform the request.
 	err := c.Perform()
 	if err != nil {
-		s.term.Errorf("Perform failed: %v", err)
+		s.term.Errorf("Perform failed for %q (auth %d): %v", attackURL, stream.AuthenticationType, err)
 		return -1
 	}
 
@@ -232,6 +233,8 @@ func (s *Scanner) routeAttack(stream Stream, route string) bool {
 
 	s.setCurlOptions(c)
 
+	_ = c.Setopt(curl.OPT_VERBOSE, 1)
+
 	// Set proper authentication type.
 	_ = c.Setopt(curl.OPT_HTTPAUTH, stream.AuthenticationType)
 	_ = c.Setopt(curl.OPT_USERPWD, fmt.Sprint(stream.Username, ":", stream.Password))
@@ -240,13 +243,12 @@ func (s *Scanner) routeAttack(stream Stream, route string) bool {
 	_ = c.Setopt(curl.OPT_URL, attackURL)
 	// Set the RTSP STREAM URI as the stream URL.
 	_ = c.Setopt(curl.OPT_RTSP_STREAM_URI, attackURL)
-	// 2 is CURL_RTSPREQ_DESCRIBE.
 	_ = c.Setopt(curl.OPT_RTSP_REQUEST, rtspDescribe)
 
 	// Perform the request.
 	err := c.Perform()
 	if err != nil {
-		s.term.Errorf("Perform failed: %v", err)
+		s.term.Errorf("Perform failed for %q (auth %d): %v", attackURL, stream.AuthenticationType, err)
 		return false
 	}
 
@@ -269,6 +271,10 @@ func (s *Scanner) routeAttack(stream Stream, route string) bool {
 }
 
 func (s *Scanner) credAttack(stream Stream, username string, password string) bool {
+	fmt.Println()
+	fmt.Println()
+	fmt.Println()
+
 	c := s.curl.Duphandle()
 
 	attackURL := fmt.Sprintf(
@@ -282,6 +288,8 @@ func (s *Scanner) credAttack(stream Stream, username string, password string) bo
 
 	s.setCurlOptions(c)
 
+	_ = c.Setopt(curl.OPT_VERBOSE, 1)
+
 	// Set proper authentication type.
 	_ = c.Setopt(curl.OPT_HTTPAUTH, stream.AuthenticationType)
 	_ = c.Setopt(curl.OPT_USERPWD, fmt.Sprint(username, ":", password))
@@ -290,13 +298,12 @@ func (s *Scanner) credAttack(stream Stream, username string, password string) bo
 	_ = c.Setopt(curl.OPT_URL, attackURL)
 	// Set the RTSP STREAM URI as the stream URL.
 	_ = c.Setopt(curl.OPT_RTSP_STREAM_URI, attackURL)
-	// 2 is CURL_RTSPREQ_DESCRIBE.
-	_ = c.Setopt(curl.OPT_RTSP_REQUEST, 2)
+	_ = c.Setopt(curl.OPT_RTSP_REQUEST, rtspDescribe)
 
 	// Perform the request.
 	err := c.Perform()
 	if err != nil {
-		s.term.Errorf("Perform failed: %v", err)
+		s.term.Errorf("Perform failed for %q (auth %d): %v", attackURL, stream.AuthenticationType, err)
 		return false
 	}
 
@@ -341,7 +348,6 @@ func (s *Scanner) validateStream(stream Stream) bool {
 	_ = c.Setopt(curl.OPT_URL, attackURL)
 	// Set the RTSP STREAM URI as the stream URL.
 	_ = c.Setopt(curl.OPT_RTSP_STREAM_URI, attackURL)
-	// 2 is CURL_RTSPREQ_SETUP.
 	_ = c.Setopt(curl.OPT_RTSP_REQUEST, rtspSetup)
 
 	_ = c.Setopt(curl.OPT_RTSP_TRANSPORT, "RTP/AVP;unicast;client_port=33332-33333")
@@ -349,7 +355,7 @@ func (s *Scanner) validateStream(stream Stream) bool {
 	// Perform the request.
 	err := c.Perform()
 	if err != nil {
-		s.term.Errorf("Perform failed: %v", err)
+		s.term.Errorf("Perform failed for %q (auth %d): %v", attackURL, stream.AuthenticationType, err)
 		return false
 	}
 


### PR DESCRIPTION
## Goal of this PR

This PR fixes #247 (and duplicates #242 and #251)

It uses an older version of curl, since versions >7.66.0 no longer handle digest authentication properly.

This is a temporary fix until [that issue is fixed in curl](https://github.com/curl/curl/pull/4750).

## How to test it

Rebuild the docker version of cameradar, or build the binary version with an old version, and ensure digest authentication works again.