### PR TITLE
Update routes with support for Lorex LHB927

### DIFF
--- a/dictionaries/routes
+++ b/dictionaries/routes
@@ -66,6 +66,14 @@ ch001.sdp
 ch01.264
 ch01.264?
 ch01.264?ptype=tcp
+ch1_0
+ch2_0
+ch3_0
+ch4_0
+ch1/0
+ch2/0
+ch3/0
+ch4/0
 ch0_0.h264
 ch0_unicast_firststream
 ch0_unicast_secondstream


### PR DESCRIPTION
The Lorex LHB927 supports RTSP streams which have routes:
ch1/0 for camera 1
ch2/0 for camera 2
...
They start counting from 1, not 0.
Alternatively, they can also be reached at:
ch1_0
ch2_0
...
Adding more routes (for cameras #3 & 4) increases the odds of finding the DVR, if for example, camera 1 is offline.