### PR TITLE
IPv6 Support

### DIFF
--- a/cmd/cameradar/cameradar.go
+++ b/cmd/cameradar/cameradar.go
@@ -25,6 +25,7 @@ func parseArguments() error {
 	pflag.IntP("scan-speed", "s", 4, "The nmap speed preset to use for scanning (lower is stealthier)")
 	pflag.DurationP("attack-interval", "I", 0, "The interval between each attack  (i.e: 2000ms, higher is stealthier)")
 	pflag.DurationP("timeout", "T", 2000*time.Millisecond, "The timeout to use for attack attempts (i.e: 2000ms)")
+	pflag.BoolP("ipv6", "6", false, "Enable ipv6")
 	pflag.BoolP("debug", "d", false, "Enable the debug logs")
 	pflag.BoolP("verbose", "v", false, "Enable the verbose logs")
 	pflag.BoolP("help", "h", false, "displays this help message")
@@ -65,6 +66,7 @@ func main() {
 	c, err := cameradar.New(
 		cameradar.WithTargets(viper.GetStringSlice("targets")),
 		cameradar.WithPorts(viper.GetStringSlice("ports")),
+		cameradar.WithIPv6(viper.GetBool("ipv6")),
 		cameradar.WithDebug(viper.GetBool("debug")),
 		cameradar.WithVerbose(viper.GetBool("verbose")),
 		cameradar.WithCustomCredentials(viper.GetString("custom-credentials")),

--- a/dictionaries/credentials.json
+++ b/dictionaries/credentials.json
@@ -11,6 +11,7 @@
     "aiphone",
     "Dinion",
     "root",
+    "rtsp",
     "service",
     "supervisor",
     "ubnt"

--- a/dictionaries/routes
+++ b/dictionaries/routes
@@ -40,6 +40,8 @@ av0_0
 av2
 avc
 avn=2
+av_stream
+av_stream/ch0
 axis-media/media.amp
 axis-media/media.amp?camera=1
 axis-media/media.amp?videocodec=h264

--- a/models.go
+++ b/models.go
@@ -46,4 +46,5 @@ type Options struct {
 	Credentials Credentials   `json:"credentials"`
 	Speed       int           `json:"speed"`
 	Timeout     time.Duration `json:"timeout"`
+	Ipv6		bool          `json:"IPv6"`
 }

--- a/scan.go
+++ b/scan.go
@@ -22,7 +22,6 @@ func (s *Scanner) Scan() ([]Stream, error) {
 	s.term.StartStep("Scanning the network")
 
 	// Run nmap command to discover open ports on the specified targets & ports.
-	s.term.Debugf("Found %d ..\n", s.ipv6)
 	
 	nmapScanner, err := nmap.NewScanner(
 		nmap.WithTargets(s.targets...),

--- a/scan.go
+++ b/scan.go
@@ -27,6 +27,7 @@ func (s *Scanner) Scan() ([]Stream, error) {
 		nmap.WithPorts(s.ports...),
 		nmap.WithServiceInfo(),
 		nmap.WithTimingTemplate(nmap.Timing(s.scanSpeed)),
+        nmap.WithIPv6Scanning(),
 	)
 	if err != nil {
 		return nil, s.term.FailStepf("unable to create network scanner: %v", err)

--- a/scan.go
+++ b/scan.go
@@ -22,18 +22,36 @@ func (s *Scanner) Scan() ([]Stream, error) {
 	s.term.StartStep("Scanning the network")
 
 	// Run nmap command to discover open ports on the specified targets & ports.
+	s.term.Debugf("Found %d ..\n", s.ipv6)
+	
 	nmapScanner, err := nmap.NewScanner(
 		nmap.WithTargets(s.targets...),
 		nmap.WithPorts(s.ports...),
 		nmap.WithServiceInfo(),
 		nmap.WithTimingTemplate(nmap.Timing(s.scanSpeed)),
-        nmap.WithIPv6Scanning(),
+		nmap.WithIPv6Scanning(),
 	)
+	
 	if err != nil {
 		return nil, s.term.FailStepf("unable to create network scanner: %v", err)
 	}
 
-	return s.scan(nmapScanner)
+    nmapScanner2, err := nmap.NewScanner(
+		nmap.WithTargets(s.targets...),
+		nmap.WithPorts(s.ports...),
+		nmap.WithServiceInfo(),
+		nmap.WithTimingTemplate(nmap.Timing(s.scanSpeed)),
+	)
+	
+	if err != nil {
+		return nil, s.term.FailStepf("unable to create network scanner: %v", err)
+	}
+
+    if s.ipv6{
+	  return s.scan(nmapScanner)
+    }else{
+      return s.scan(nmapScanner2)	
+    }
 }
 
 func (s *Scanner) scan(nmapScanner nmap.ScanRunner) ([]Stream, error) {

--- a/scanner.go
+++ b/scanner.go
@@ -23,6 +23,7 @@ type Scanner struct {
 
 	targets                  []string
 	ports                    []string
+	ipv6					 bool
 	debug                    bool
 	verbose                  bool
 	scanSpeed                int
@@ -109,6 +110,13 @@ func WithPorts(ports []string) func(s *Scanner) {
 func WithDebug(debug bool) func(s *Scanner) {
 	return func(s *Scanner) {
 		s.debug = debug
+	}
+}
+
+// WithDebug specifies whether or not to enable ipv6.
+func WithIPv6(ipv6 bool) func(s *Scanner) {
+	return func(s *Scanner) {
+		s.ipv6 = ipv6
 	}
 }
 


### PR DESCRIPTION
Saw a support ticket for the inclusion of IPv6.

Here is my attempt of adding a -6 switch, and manipulating the nmap scanner, to include the ipv6 flag.

Works on my local test machine (with vlc streaming over rtsp), but have not tried it in the real world, so may require additional testing.