### PR TITLE
Update curl-dev dependency version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' >> /etc/apk/repositori
 RUN apk --update add --no-cache nmap \
     nmap-nselibs \
     nmap-scripts \
-    curl-dev==7.64.0-r3
+    curl-dev==7.64.0-r5
 
 WORKDIR /app/cameradar
 COPY --from=build-env /go/src/github.com/Ullaakut/cameradar/dictionaries/ /app/dictionaries/


### PR DESCRIPTION
## Goal of this PR

This PR updates the Dockerfile to use the updated version of the `curl-dev` dependency available on the `http://dl-cdn.alpinelinux.org/alpine/v3.9/main` repository. Unfortunately, this might not be the end of trouble, as it might get updated again in the future, in which case another PR will be required.

## How to test it

Run `docker build -t cameradar .` at the root of the repository.