### PR TITLE
Display nmap warnings correctly before exiting when a fatal error occurs

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -37,12 +37,11 @@ func (s *Scanner) Scan() ([]Stream, error) {
 
 func (s *Scanner) scan(nmapScanner nmap.ScanRunner) ([]Stream, error) {
 	results, warnings, err := nmapScanner.Run()
-	if err != nil {
-		return nil, s.term.FailStepf("error while scanning network: %v", err)
-	}
-
 	for _, warning := range warnings {
 		s.term.Infoln("[Nmap Warning]", warning)
+	}
+	if err != nil {
+		return nil, s.term.FailStepf("error while scanning network: %v", err)
 	}
 
 	// Get streams from nmap results.


### PR DESCRIPTION
## Goal of this PR

This PR is part of solving #279. It switches the order in which we check for warnings and errors when scanning, so that nmap warnings are no longer discarded in the case of a fatal error.