### PR TITLE
Ignore non-IPv4 addresses in nmap output when building streams list

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -57,6 +57,9 @@ func (s *Scanner) scan(nmapScanner nmap.ScanRunner) ([]Stream, error) {
 			}
 
 			for _, address := range host.Addresses {
+				if address.AddrType != "ipv4" {
+					continue
+				}
 				streams = append(streams, Stream{
 					Device:  port.Service.Product,
 					Address: address.Addr,


### PR DESCRIPTION
Recent versions of nmap include additional elements in the XML output, such as MAC addresses. These entries currently pollute results and error output.
Additionally, IPv6 addresses are not supported by the way URLs are currently built, so they should also be skipped.
Example output:
```
  > Perform failed for "rtsp://:@38:AF:29:DA:71:81:554//0x8b6c42" (auth 0): curl: URL using bad/illegal format or missing URL
  > Perform failed for "rtsp://:@38:AF:29:DA:71:81:554/cam/realmonitor?channel=0&subtype=0" (auth 0): curl: URL using bad/illegal format or missing URL
  > Perform failed for "rtsp://:@38:AF:29:DA:71:81:554/cam/realmonitor?channel=1&subtype=0" (auth 0): curl: URL using bad/illegal format or missing URL
  > Perform failed for "rtsp://:@38:AF:29:DA:71:81:554/cam/realmonitor?channel=1&subtype=1" (auth 0): curl: URL using bad/illegal format or missing URL
````