### PR TITLE
 Work around libcurl RTSP bug by pinning curl to 7.64.0-r5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,14 @@ FROM golang:alpine AS build-env
 COPY . /go/src/github.com/Ullaakut/cameradar
 WORKDIR /go/src/github.com/Ullaakut/cameradar/cmd/cameradar
 
+# Necessary to install curl v7.64.0-r5.
+# Fix for https://github.com/Ullaakut/cameradar/issues/247
+# And a bug when curl doesn't change request method
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' >> /etc/apk/repositories
 RUN apk update && \
     apk upgrade && \
     apk add nmap nmap-nselibs nmap-scripts \
-    curl curl-dev \
+    curl curl-dev==7.64.0-r5 \
     gcc \
     libc-dev \
     git \
@@ -19,8 +23,6 @@ RUN go build -o cameradar
 # Final stage
 FROM alpine
 
-# Necessary to install curl v7.64.0-r3.
-# Fix for https://github.com/Ullaakut/cameradar/issues/247
 RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.9/main' >> /etc/apk/repositories
 
 RUN apk --update add --no-cache nmap \


### PR DESCRIPTION
There is a regression in libcurl where calling "curl_easy_setopt(h, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_DESCRIBE);" has no effect. The CURL_RTSPREQ_DESCRIBE request is ignored, and libcurl only performs an OPTIONS method instead.
As a result, the scanner cannot successfully send DESCRIBE requests to RTSP endpoints.
To ensure correct behavior, the project must be built against the downgraded libcurl version, not only run with it at runtime.
On a system with the affected libcurl version, running:
```bash
/app/cameradar # apk list libcurl
WARNING: opening from cache https://dl-cdn.alpinelinux.org/alpine/v3.22/main: No such file or directory
WARNING: opening from cache https://dl-cdn.alpinelinux.org/alpine/v3.22/community: No such file or directory
WARNING: opening from cache http://dl-cdn.alpinelinux.org/alpine/v3.9/main: No such file or directory
libcurl-8.14.1-r1 x86_64 {curl} (curl) [installed]
/app/cameradar # #./cameradar --targets 172.18.0.1 --ports 8554 -d -v --attack-interval 10ms
/app/cameradar # ./cameradar --targets 172.18.0.1 --ports 8559 -d -v --attack-interval 10ms
Loading credentials...ok
  > Loading credentials dictionary from path "/app/dictionaries/credentials.json"
  > Loaded 16 usernames and 59 passwords
Loading routes...ok
  > Loading routes dictionary from path "/app/dictionaries/routes"
  > Loaded 197 routes
Scanning the network...ok
  > Found 1 RTSP streams
Attacking routes of 1 streams...*   Trying 172.18.0.1:8559...
* Connected to 172.18.0.1 (172.18.0.1) port 8559
> OPTIONS * RTSP/1.0
CSeq: 1

* Request completely sent off
< RTSP/1.0 200 OK
< CSeq: 1
< Public: OPTIONS, DESCRIBE, ANNOUNCE, GET_PARAMETER, PAUSE, PLAY, RECORD, SETUP, SET_PARAMETER, TEARDOWN
< Server: GStreamer RTSP server
< Date: Thu, 25 Sep 2025 19:47:12 GMT
< 
* Connection #0 to host 172.18.0.1 left intact
ok
  > DESCRIBE rtsp://:@172.18.0.1:8559//0x8b6c42 RTSP/1.0 > 200
Attempting to detect authentication methods of 1 streams...*   Trying 172.18.0.1:8559...
* Connected to 172.18.0.1 (172.18.0.1) port 8559
> OPTIONS * RTSP/1.0
CSeq: 1

* Request completely sent off
< RTSP/1.0 200 OK
< CSeq: 1
< Public: OPTIONS, DESCRIBE, ANNOUNCE, GET_PARAMETER, PAUSE, PLAY, RECORD, SETUP, SET_PARAMETER, TEARDOWN
< Server: GStreamer RTSP server
< Date: Thu, 25 Sep 2025 19:47:12 GMT
< 
* Connection #0 to host 172.18.0.1 left intact
ok
  > DESCRIBE rtsp://172.18.0.1:8559// RTSP/1.0 > 0
  > Stream rtsp://:@172.18.0.1:8559// uses no authentication method
Attacking credentials of 1 streams...*   Trying 172.18.0.1:8559...
* Connected to 172.18.0.1 (172.18.0.1) port 8559
> OPTIONS * RTSP/1.0
CSeq: 1

* Request completely sent off
< RTSP/1.0 200 OK
< CSeq: 1
< Public: OPTIONS, DESCRIBE, ANNOUNCE, GET_PARAMETER, PAUSE, PLAY, RECORD, SETUP, SET_PARAMETER, TEARDOWN
< Server: GStreamer RTSP server
< Date: Thu, 25 Sep 2025 19:47:12 GMT
< 
* Connection #0 to host 172.18.0.1 left intact
ok
  > DESCRIBE rtsp://:@172.18.0.1:8559// RTSP/1.0 > 200
Validating that streams are accessible...*   Trying 172.18.0.1:8559...
* Connected to 172.18.0.1 (172.18.0.1) port 8559
> OPTIONS * RTSP/1.0
CSeq: 1

* Request completely sent off
< RTSP/1.0 200 OK
< CSeq: 1
< Public: OPTIONS, DESCRIBE, ANNOUNCE, GET_PARAMETER, PAUSE, PLAY, RECORD, SETUP, SET_PARAMETER, TEARDOWN
< Server: GStreamer RTSP server
< Date: Thu, 25 Sep 2025 19:47:12 GMT
< 
* Connection #0 to host 172.18.0.1 left intact
ok
  > SETUP rtsp://:@172.18.0.1:8559// RTSP/1.0 > 200
▶	Device RTSP URL:	rtsp://:@172.18.0.1:8559//
	Available:		✔
	Device model:		GStreamer rtspd

	IP address:		172.18.0.1
	RTSP port:		8559
	This camera does not require authentication
	Username:		
	Password:		
	RTSP routes:
				//


✔ Successful attack: one device was accessed
```