### PR TITLE
Add support for spaces and colons in username and password

### DIFF
--- a/attack.go
+++ b/attack.go
@@ -230,9 +230,7 @@ func (s *Scanner) routeAttack(stream Stream, route string) bool {
 	c := s.curl.Duphandle()
 
 	attackURL := fmt.Sprintf(
-		"rtsp://%s:%s@%s:%d/%s",
-		stream.Username,
-		stream.Password,
+		"rtsp://%s:%d/%s",
 		stream.Address,
 		stream.Port,
 		route,
@@ -242,7 +240,8 @@ func (s *Scanner) routeAttack(stream Stream, route string) bool {
 
 	// Set proper authentication type.
 	_ = c.Setopt(curl.OPT_HTTPAUTH, stream.AuthenticationType)
-	_ = c.Setopt(curl.OPT_USERPWD, fmt.Sprint(stream.Username, ":", stream.Password))
+	_ = c.Setopt(curl.OPT_USERNAME, stream.Username)
+	_ = c.Setopt(curl.OPT_PASSWORD, stream.Password)
 
 	// Send a request to the URL of the stream we want to attack.
 	_ = c.Setopt(curl.OPT_URL, attackURL)
@@ -279,9 +278,7 @@ func (s *Scanner) credAttack(stream Stream, username string, password string) bo
 	c := s.curl.Duphandle()
 
 	attackURL := fmt.Sprintf(
-		"rtsp://%s:%s@%s:%d/%s",
-		username,
-		password,
+		"rtsp://%s:%d/%s",
 		stream.Address,
 		stream.Port,
 		stream.Route(),
@@ -291,7 +288,8 @@ func (s *Scanner) credAttack(stream Stream, username string, password string) bo
 
 	// Set proper authentication type.
 	_ = c.Setopt(curl.OPT_HTTPAUTH, stream.AuthenticationType)
-	_ = c.Setopt(curl.OPT_USERPWD, fmt.Sprint(username, ":", password))
+	_ = c.Setopt(curl.OPT_USERNAME, username)
+	_ = c.Setopt(curl.OPT_PASSWORD, password)
 
 	// Send a request to the URL of the stream we want to attack.
 	_ = c.Setopt(curl.OPT_URL, attackURL)
@@ -329,9 +327,7 @@ func (s *Scanner) validateStream(stream Stream) bool {
 	c := s.curl.Duphandle()
 
 	attackURL := fmt.Sprintf(
-		"rtsp://%s:%s@%s:%d/%s",
-		stream.Username,
-		stream.Password,
+		"rtsp://%s:%d/%s",
 		stream.Address,
 		stream.Port,
 		stream.Route(),
@@ -341,7 +337,8 @@ func (s *Scanner) validateStream(stream Stream) bool {
 
 	// Set proper authentication type.
 	_ = c.Setopt(curl.OPT_HTTPAUTH, stream.AuthenticationType)
-	_ = c.Setopt(curl.OPT_USERPWD, fmt.Sprint(stream.Username, ":", stream.Password))
+	_ = c.Setopt(curl.OPT_USERNAME, stream.Username)
+	_ = c.Setopt(curl.OPT_PASSWORD, stream.Password)
 
 	// Send a request to the URL of the stream we want to attack.
 	_ = c.Setopt(curl.OPT_URL, attackURL)


### PR DESCRIPTION
Currently, there is no way to specify a username or password that contains spaces or colons. When these characters are included, they break the RTSP URL, causing the remote connection to fail.
```
* Connected to 172.18.0.1 (172.18.0.1) port 8559 (#0)
* Server auth using Basic with user 'Admin'
> DESCRIBE rtsp://Admin:admin pass@172.18.0.1:8559/wfov RTSP/1.0
CSeq: 1
Accept: application/sdp
Authorization: Basic QWRtaW46YWRtaW4gcGFzcw==

* Empty reply from server
* The CSeq of this request 1 did not match the response 0
* Connection #0 to host 172.18.0.1 left intact
```
There’s no need to include the username and password in the RTSP URL. Just use an alternative approach to set authentication instead.
@Ullaakut There seem to be a few other issues affecting the current master build. Could you please review my earlier pull requests as well?