### PR TITLE
fix: command/flags to prevent subcommand being required

### DIFF
--- a/cmd/cameradar/main.go
+++ b/cmd/cameradar/main.go
@@ -38,11 +38,10 @@ var (
 
 var flags = cmd.Flags{
 	&cli.StringSliceFlag{
-		Name:     flagTargets,
-		Usage:    "The targets on which to scan for open RTSP streams in a network range format",
-		Aliases:  []string{"t"},
-		Sources:  cli.EnvVars(strcase.ToSNAKE(flagTargets)),
-		Required: true,
+		Name:    flagTargets,
+		Usage:   "The targets on which to scan for open RTSP streams in a network range format",
+		Aliases: []string{"t"},
+		Sources: cli.EnvVars(strcase.ToSNAKE(flagTargets)),
 	},
 	&cli.StringSliceFlag{
 		Name:    flagPorts,
@@ -128,19 +127,13 @@ func realMain() (code int) {
 		}
 	}()
 
-	scanCommand := &cli.Command{
-		Name:   "scan",
-		Usage:  "Scan targets for RTSP streams",
-		Flags:  flags,
-		Action: runCameradar,
-	}
-
 	app := &cli.Command{
-		Name:           "Cameradar",
-		Version:        version,
-		DefaultCommand: scanCommand.Name,
+		Name:    "Cameradar",
+		Version: version,
+		Usage:   "Scan targets for RTSP streams",
+		Flags:   flags,
+		Action:  runCameradar,
 		Commands: []*cli.Command{
-			scanCommand,
 			{
 				Name:   "version",
 				Usage:  "Print version information",


### PR DESCRIPTION
## Goal of this PR

Fixes #410 

### Root cause

* `urfave/cli/v3` parses flags on the current command before default-command fallback.

### Fix

* Made the root command execute `runCameradar` directly (instead of relying on DefaultCommand behavior).
* Removed global `Required: true` from targets so non-scan subcommands (like version) can run without scan inputs.

### Resulting behavior

* `cameradar --targets=192.168.1.0/24 --ui plain` works.
* `cameradar version` works without `--targets`.
* Normal scan execution still errors clearly when --targets is missing.

### Validation

## How did I test it?

Those commands behave as expected.

```
go run ./cmd/cameradar version
go run ./cmd/cameradar --ui plain
go run ./cmd/cameradar --targets=192.168.1.0/24 --ui plain
```
