### PR TITLE
feat: add framecheck mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,10 +282,8 @@ playback and waiting for an RTP packet.
 Framecheck means:
 
 - Cameradar only accepts `200 OK` when it can confirm frame generation.
-- If no RTP packet arrives, Cameradar treats the result as a false positive and
-    continues attacking.
-- Route checks remain compatible with authentication challenges seen during
-    probing.
+- If no RTP packet arrives, Cameradar treats the result as a false positive and continues attacking.
+- Route checks remain compatible with authentication challenges seen during probing.
 
 `--framecheck` is disabled by default because it adds RTSP requests and can
 significantly increase attack duration.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,44 @@ docker run --rm -t --net=host \
 > [!WARNING]  
 > `--scan-speed` only applies to the `nmap` scanner.
 
+### Reduce false positives with `--framecheck`
+
+Some cameras do not fully follow RTSP behavior and can return `200 OK` even when
+the route or credentials are wrong.
+
+When you enable `--framecheck`, Cameradar validates each `200 OK` by attempting
+playback and waiting for an RTP packet.
+
+Framecheck means:
+
+- Cameradar only accepts `200 OK` when it can confirm frame generation.
+- If no RTP packet arrives, Cameradar treats the result as a false positive and
+    continues attacking.
+- Route checks remain compatible with authentication challenges seen during
+    probing.
+
+`--framecheck` is disabled by default because it adds RTSP requests and can
+significantly increase attack duration.
+
+Example with Docker:
+
+```bash
+docker run --rm -t --net=host \
+        ullaakut/cameradar \
+        --targets 192.168.1.0/24 \
+        --ports "554,8554" \
+        --framecheck
+```
+
+Example with local binary and environment variable:
+
+```bash
+FRAMECHECK=true \
+        cameradar \
+        --targets 192.168.1.0/24 \
+        --ports "554,8554"
+```
+
 ## Security and responsible use
 
 Cameradar is a penetration testing tool.

--- a/cmd/cameradar/cameradar.go
+++ b/cmd/cameradar/cameradar.go
@@ -83,6 +83,7 @@ func runCameradar(ctx context.Context, cmd *cli.Command) error {
 			cmd.Int16(flagScanSpeed),
 			cmd.Duration(flagAttackInterval),
 			cmd.Duration(flagTimeout),
+			cmd.Bool(flagFrameCheck),
 			cmd.Bool(flagSkipScan),
 			cmd.Bool(flagDebug),
 			resolvedMode,
@@ -108,7 +109,8 @@ func runCameradar(ctx context.Context, cmd *cli.Command) error {
 
 	interval := cmd.Duration(flagAttackInterval)
 	timeout := cmd.Duration(flagTimeout)
-	attacker, err := attack.New(dictionary, interval, timeout, reporter)
+	frameCheck := cmd.Bool(flagFrameCheck)
+	attacker, err := attack.New(dictionary, interval, timeout, frameCheck, reporter)
 	if err != nil {
 		return fmt.Errorf("creating attacker: %w", err)
 	}
@@ -147,6 +149,7 @@ func buildStartupOptions(
 	scanSpeed int16,
 	attackInterval time.Duration,
 	timeout time.Duration,
+	frameCheck bool,
 	skipScan bool,
 	debug bool,
 	mode cameradar.Mode,
@@ -158,6 +161,7 @@ func buildStartupOptions(
 		"custom-credentials: " + fallbackValue(credsPath, "builtin"),
 		"scanner: " + fallbackValue(scanner, "nmap"),
 		"scan-speed: " + strconv.FormatInt(int64(scanSpeed), 10),
+		"frame-check: " + strconv.FormatBool(frameCheck),
 		"skip-scan: " + strconv.FormatBool(skipScan),
 		"attack-interval: " + attackInterval.String(),
 		"timeout: " + timeout.String(),

--- a/cmd/cameradar/main.go
+++ b/cmd/cameradar/main.go
@@ -24,6 +24,7 @@ const (
 	flagScanSpeed         = "scan-speed"
 	flagAttackInterval    = "attack-interval"
 	flagTimeout           = "timeout"
+	flagFrameCheck        = "framecheck"
 	flagSkipScan          = "skip-scan"
 	flagDebug             = "debug"
 	flagUI                = "ui"
@@ -88,6 +89,12 @@ var flags = cmd.Flags{
 		Aliases: []string{"T"},
 		Sources: cli.EnvVars(strcase.ToSNAKE(flagTimeout)),
 		Value:   2000 * time.Millisecond,
+	},
+	&cli.BoolFlag{
+		Name:    flagFrameCheck,
+		Usage:   "When DESCRIBE returns 200 OK, require a frame probe check before accepting routes or credentials (slower)",
+		Sources: cli.EnvVars(strcase.ToSNAKE(flagFrameCheck)),
+		Value:   false,
 	},
 	&cli.BoolFlag{
 		Name:    flagSkipScan,

--- a/internal/attack/attacker.go
+++ b/internal/attack/attacker.go
@@ -346,6 +346,7 @@ func (a Attacker) acceptStatusOK(ctx context.Context, stream cameradar.Stream, s
 	return ok
 }
 
+//nolint:cyclop // Splitting this function does not make it clearer.
 func (a Attacker) probeFrameGeneration(ctx context.Context, stream cameradar.Stream) (bool, base.StatusCode, error) {
 	if ctx.Err() != nil {
 		return false, 0, ctx.Err()

--- a/internal/attack/attacker.go
+++ b/internal/attack/attacker.go
@@ -339,6 +339,9 @@ func (a Attacker) acceptStatusOK(ctx context.Context, stream cameradar.Stream, s
 		a.reporter.Debug(step, fmt.Sprintf("Keeping RTSP 200 route for %s because frame probe returned RTSP %d", stream, statusCode))
 		return true
 	}
+	if ok {
+		a.reporter.Debug(step, fmt.Sprintf("Frame probe succeeded for %s", stream))
+	}
 	if !ok {
 		a.reporter.Debug(step, fmt.Sprintf("Ignoring RTSP 200 for %s because no RTP packet was received", stream))
 	}
@@ -348,6 +351,18 @@ func (a Attacker) acceptStatusOK(ctx context.Context, stream cameradar.Stream, s
 
 //nolint:cyclop // Splitting this function does not make it clearer.
 func (a Attacker) probeFrameGeneration(ctx context.Context, stream cameradar.Stream) (bool, base.StatusCode, error) {
+	ok, statusCode, err := a.probeFrameGenerationWithProtocol(ctx, stream, nil)
+	if ok || statusCode != 0 || err != nil {
+		return ok, statusCode, err
+	}
+
+	// When UDP packets are blocked or not delivered, retry over interleaved TCP.
+	tcpProtocol := gortsplib.ProtocolTCP
+	return a.probeFrameGenerationWithProtocol(ctx, stream, &tcpProtocol)
+}
+
+//nolint:cyclop // Splitting this function does not make it clearer.
+func (a Attacker) probeFrameGenerationWithProtocol(ctx context.Context, stream cameradar.Stream, protocol *gortsplib.Protocol) (bool, base.StatusCode, error) {
 	if ctx.Err() != nil {
 		return false, 0, ctx.Err()
 	}
@@ -357,6 +372,10 @@ func (a Attacker) probeFrameGeneration(ctx context.Context, stream cameradar.Str
 		return false, 0, fmt.Errorf("starting rtsp client: %w", err)
 	}
 	defer client.Close()
+
+	if protocol != nil {
+		client.Protocol = protocol
+	}
 
 	desc, _, err := a.describeWithRetry(ctx, client, stream)
 	if err != nil {
@@ -370,12 +389,12 @@ func (a Attacker) probeFrameGeneration(ctx context.Context, stream cameradar.Str
 		return false, 0, nil
 	}
 
-	_, err = client.Setup(desc.BaseURL, desc.Medias[0], 0, 0)
+	err = client.SetupAll(desc.BaseURL, desc.Medias)
 	if err != nil {
 		if code, ok := badStatusCode(err); ok {
 			return false, code, nil
 		}
-		return false, 0, fmt.Errorf("performing setup request at %q: %w", stream, err)
+		return false, 0, fmt.Errorf("performing setup requests at %q: %w", stream, err)
 	}
 
 	rtpPacketReceived := make(chan struct{}, 1)

--- a/internal/attack/attacker.go
+++ b/internal/attack/attacker.go
@@ -349,7 +349,6 @@ func (a Attacker) acceptStatusOK(ctx context.Context, stream cameradar.Stream, s
 	return ok
 }
 
-//nolint:cyclop // Splitting this function does not make it clearer.
 func (a Attacker) probeFrameGeneration(ctx context.Context, stream cameradar.Stream) (bool, base.StatusCode, error) {
 	ok, statusCode, err := a.probeFrameGenerationWithProtocol(ctx, stream, nil)
 	if ok || statusCode != 0 || err != nil {

--- a/internal/attack/attacker.go
+++ b/internal/attack/attacker.go
@@ -10,7 +10,9 @@ import (
 	"github.com/bluenviron/gortsplib/v5"
 	"github.com/bluenviron/gortsplib/v5/pkg/base"
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
 	"github.com/bluenviron/gortsplib/v5/pkg/liberrors"
+	"github.com/pion/rtp"
 )
 
 // Route that should never be a constructor default.
@@ -38,10 +40,11 @@ type Attacker struct {
 	reporter       Reporter
 	attackInterval time.Duration
 	timeout        time.Duration
+	framecheck     bool
 }
 
 // New builds an Attacker with the provided dependencies.
-func New(dict Dictionary, attackInterval, timeout time.Duration, reporter Reporter) (Attacker, error) {
+func New(dict Dictionary, attackInterval, timeout time.Duration, framecheck bool, reporter Reporter) (Attacker, error) {
 	if dict == nil {
 		return Attacker{}, errors.New("dictionary is required")
 	}
@@ -50,6 +53,7 @@ func New(dict Dictionary, attackInterval, timeout time.Duration, reporter Report
 		dictionary:     dict,
 		attackInterval: attackInterval,
 		timeout:        timeout,
+		framecheck:     framecheck,
 		reporter:       reporter,
 	}, nil
 }
@@ -217,7 +221,7 @@ func (a Attacker) attackCredentialsForStream(ctx context.Context, target camerad
 			}
 
 			a.reporter.Progress(cameradar.StepAttackCredentials, cameradar.ProgressTickMessage())
-			ok, err := a.credAttack(target, username, password)
+			ok, err := a.credAttack(ctx, target, username, password)
 			if err != nil {
 				target.CredentialsFound = false
 
@@ -253,7 +257,7 @@ func (a Attacker) attackRoutesForStream(ctx context.Context, target cameradar.St
 	if emitProgress {
 		a.reporter.Progress(cameradar.StepAttackRoutes, cameradar.ProgressTickMessage())
 	}
-	ok, err := a.routeAttack(target, dummyRoute)
+	ok, err := a.routeAttack(ctx, target, dummyRoute)
 	if err != nil {
 		a.reporter.Debug(cameradar.StepAttackRoutes, fmt.Sprintf("route probe failed for %s:%d: %v", target.Address.String(), target.Port, err))
 		return target, nil
@@ -275,7 +279,7 @@ func (a Attacker) attackRoutesForStream(ctx context.Context, target cameradar.St
 		if emitProgress {
 			a.reporter.Progress(cameradar.StepAttackRoutes, cameradar.ProgressTickMessage())
 		}
-		ok, err := a.routeAttack(target, route)
+		ok, err := a.routeAttack(ctx, target, route)
 		if err != nil {
 			a.reporter.Debug(cameradar.StepAttackRoutes, fmt.Sprintf("route attempt failed for %s:%d (%s): %v", target.Address.String(), target.Port, route, err))
 			return target, nil
@@ -290,7 +294,7 @@ func (a Attacker) attackRoutesForStream(ctx context.Context, target cameradar.St
 	return target, nil
 }
 
-func (a Attacker) routeAttack(stream cameradar.Stream, route string) (bool, error) {
+func (a Attacker) routeAttack(ctx context.Context, stream cameradar.Stream, route string) (bool, error) {
 	stream.Routes = []string{route}
 	code, err := a.describeStatus(stream)
 	if err != nil {
@@ -298,11 +302,14 @@ func (a Attacker) routeAttack(stream cameradar.Stream, route string) (bool, erro
 	}
 
 	a.reporter.Debug(cameradar.StepAttackRoutes, fmt.Sprintf("DESCRIBE %s RTSP/1.0 > %d", stream, code))
-	access := code == base.StatusOK || code == base.StatusUnauthorized || code == base.StatusForbidden
-	return access, nil
+	if code == base.StatusOK && !a.acceptStatusOK(ctx, stream, cameradar.StepAttackRoutes) {
+		return false, nil
+	}
+
+	return code == base.StatusOK || code == base.StatusUnauthorized || code == base.StatusForbidden, nil
 }
 
-func (a Attacker) credAttack(stream cameradar.Stream, username, password string) (bool, error) {
+func (a Attacker) credAttack(ctx context.Context, stream cameradar.Stream, username, password string) (bool, error) {
 	stream.Username = username
 	stream.Password = password
 	code, err := a.describeStatus(stream)
@@ -311,7 +318,109 @@ func (a Attacker) credAttack(stream cameradar.Stream, username, password string)
 	}
 
 	a.reporter.Debug(cameradar.StepAttackCredentials, fmt.Sprintf("DESCRIBE %s RTSP/1.0 > %d", stream, code))
+	if code == base.StatusOK && !a.acceptStatusOK(ctx, stream, cameradar.StepAttackCredentials) {
+		return false, nil
+	}
+
 	return code == base.StatusOK || code == base.StatusNotFound, nil
+}
+
+func (a Attacker) acceptStatusOK(ctx context.Context, stream cameradar.Stream, step cameradar.Step) bool {
+	if !a.framecheck {
+		return true
+	}
+
+	ok, statusCode, err := a.probeFrameGeneration(ctx, stream)
+	if err != nil {
+		a.reporter.Debug(step, fmt.Sprintf("Frame probe failed for %s: %v", stream, err))
+		return false
+	}
+	if !ok && step == cameradar.StepAttackRoutes && (statusCode == base.StatusUnauthorized || statusCode == base.StatusForbidden) {
+		a.reporter.Debug(step, fmt.Sprintf("Keeping RTSP 200 route for %s because frame probe returned RTSP %d", stream, statusCode))
+		return true
+	}
+	if !ok {
+		a.reporter.Debug(step, fmt.Sprintf("Ignoring RTSP 200 for %s because no RTP packet was received", stream))
+	}
+
+	return ok
+}
+
+func (a Attacker) probeFrameGeneration(ctx context.Context, stream cameradar.Stream) (bool, base.StatusCode, error) {
+	if ctx.Err() != nil {
+		return false, 0, ctx.Err()
+	}
+
+	client, err := a.newRTSPClient(stream)
+	if err != nil {
+		return false, 0, fmt.Errorf("starting rtsp client: %w", err)
+	}
+	defer client.Close()
+
+	desc, _, err := a.describeWithRetry(ctx, client, stream)
+	if err != nil {
+		if code, ok := badStatusCode(err); ok {
+			return false, code, nil
+		}
+		return false, 0, fmt.Errorf("performing describe request at %q: %w", stream, err)
+	}
+
+	if desc == nil || len(desc.Medias) == 0 {
+		return false, 0, nil
+	}
+
+	_, err = client.Setup(desc.BaseURL, desc.Medias[0], 0, 0)
+	if err != nil {
+		if code, ok := badStatusCode(err); ok {
+			return false, code, nil
+		}
+		return false, 0, fmt.Errorf("performing setup request at %q: %w", stream, err)
+	}
+
+	rtpPacketReceived := make(chan struct{}, 1)
+	client.OnPacketRTPAny(func(_ *description.Media, _ format.Format, _ *rtp.Packet) {
+		select {
+		case rtpPacketReceived <- struct{}{}:
+		default:
+		}
+	})
+
+	_, err = client.Play(nil)
+	if err != nil {
+		if code, ok := badStatusCode(err); ok {
+			return false, code, nil
+		}
+		return false, 0, fmt.Errorf("performing play request at %q: %w", stream, err)
+	}
+
+	timer := time.NewTimer(frameProbeTimeout(a.timeout))
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false, 0, ctx.Err()
+	case <-timer.C:
+		return false, 0, nil
+	case <-rtpPacketReceived:
+		return true, 0, nil
+	}
+}
+
+func badStatusCode(err error) (base.StatusCode, bool) {
+	var badStatus liberrors.ErrClientBadStatusCode
+	if !errors.As(err, &badStatus) {
+		return 0, false
+	}
+
+	return badStatus.Code, true
+}
+
+func frameProbeTimeout(timeout time.Duration) time.Duration {
+	if timeout > 0 {
+		return timeout
+	}
+
+	return 2 * time.Second
 }
 
 func (a Attacker) validateStream(ctx context.Context, stream cameradar.Stream, emitProgress bool) (cameradar.Stream, error) {

--- a/internal/attack/attacker.go
+++ b/internal/attack/attacker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Ullaakut/cameradar/v6"
@@ -17,6 +18,8 @@ import (
 
 // Route that should never be a constructor default.
 const dummyRoute = "0x8b6c42"
+
+var errFrameProbeNoMedias = errors.New("describe succeeded but no media tracks found")
 
 // Dictionary provides dictionaries for routes, usernames and passwords.
 type Dictionary interface {
@@ -330,8 +333,12 @@ func (a Attacker) acceptStatusOK(ctx context.Context, stream cameradar.Stream, s
 		return true
 	}
 
-	ok, statusCode, err := a.probeFrameGeneration(ctx, stream)
+	ok, statusCode, err := a.probeFrameGeneration(ctx, stream, step)
 	if err != nil {
+		if errors.Is(err, errFrameProbeNoMedias) {
+			a.reporter.Debug(step, fmt.Sprintf("Ignoring RTSP 200 for %s because DESCRIBE returned no media tracks", stream))
+			return false
+		}
 		a.reporter.Debug(step, fmt.Sprintf("Frame probe failed for %s: %v", stream, err))
 		return false
 	}
@@ -349,19 +356,24 @@ func (a Attacker) acceptStatusOK(ctx context.Context, stream cameradar.Stream, s
 	return ok
 }
 
-func (a Attacker) probeFrameGeneration(ctx context.Context, stream cameradar.Stream) (bool, base.StatusCode, error) {
-	ok, statusCode, err := a.probeFrameGenerationWithProtocol(ctx, stream, nil)
+func (a Attacker) probeFrameGeneration(ctx context.Context, stream cameradar.Stream, step cameradar.Step) (bool, base.StatusCode, error) {
+	ok, statusCode, err := a.probeFrameGenerationWithProtocol(ctx, stream, nil, step)
 	if ok || statusCode != 0 || err != nil {
 		return ok, statusCode, err
 	}
 
 	// When UDP packets are blocked or not delivered, retry over interleaved TCP.
 	tcpProtocol := gortsplib.ProtocolTCP
-	return a.probeFrameGenerationWithProtocol(ctx, stream, &tcpProtocol)
+	return a.probeFrameGenerationWithProtocol(ctx, stream, &tcpProtocol, step)
 }
 
 //nolint:cyclop // Splitting this function does not make it clearer.
-func (a Attacker) probeFrameGenerationWithProtocol(ctx context.Context, stream cameradar.Stream, protocol *gortsplib.Protocol) (bool, base.StatusCode, error) {
+func (a Attacker) probeFrameGenerationWithProtocol(
+	ctx context.Context,
+	stream cameradar.Stream,
+	protocol *gortsplib.Protocol,
+	step cameradar.Step,
+) (bool, base.StatusCode, error) {
 	if ctx.Err() != nil {
 		return false, 0, ctx.Err()
 	}
@@ -376,8 +388,11 @@ func (a Attacker) probeFrameGenerationWithProtocol(ctx context.Context, stream c
 		client.Protocol = protocol
 	}
 
-	desc, _, err := a.describeWithRetry(ctx, client, stream)
+	desc, _, err := a.describeWithRetry(ctx, client, stream, step)
 	if err != nil {
+		if noMediaSDPError(err) {
+			return false, 0, errFrameProbeNoMedias
+		}
 		if code, ok := badStatusCode(err); ok {
 			return false, code, nil
 		}
@@ -385,7 +400,7 @@ func (a Attacker) probeFrameGenerationWithProtocol(ctx context.Context, stream c
 	}
 
 	if desc == nil || len(desc.Medias) == 0 {
-		return false, 0, nil
+		return false, 0, errFrameProbeNoMedias
 	}
 
 	err = client.SetupAll(desc.BaseURL, desc.Medias)
@@ -434,6 +449,19 @@ func badStatusCode(err error) (base.StatusCode, bool) {
 	return badStatus.Code, true
 }
 
+func noMediaSDPError(err error) bool {
+	var sdpErr liberrors.ErrClientSDPInvalid
+	if !errors.As(err, &sdpErr) {
+		return false
+	}
+
+	if sdpErr.Err == nil {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(sdpErr.Err.Error()), "no media streams")
+}
+
 func frameProbeTimeout(timeout time.Duration) time.Duration {
 	if timeout > 0 {
 		return timeout
@@ -457,7 +485,7 @@ func (a Attacker) validateStream(ctx context.Context, stream cameradar.Stream, e
 	}
 	defer client.Close()
 
-	desc, res, err := a.describeWithRetry(ctx, client, stream)
+	desc, res, err := a.describeWithRetry(ctx, client, stream, cameradar.StepValidateStreams)
 	if err != nil {
 		return a.handleDescribeError(stream, err)
 	}
@@ -481,7 +509,12 @@ func (a Attacker) validateStream(ctx context.Context, stream cameradar.Stream, e
 	return stream, nil
 }
 
-func (a Attacker) describeWithRetry(ctx context.Context, client *gortsplib.Client, stream cameradar.Stream) (*description.Session, *base.Response, error) {
+func (a Attacker) describeWithRetry(
+	ctx context.Context,
+	client *gortsplib.Client,
+	stream cameradar.Stream,
+	step cameradar.Step,
+) (*description.Session, *base.Response, error) {
 	u, err := stream.URL()
 	if err != nil {
 		return nil, nil, fmt.Errorf("building rtsp url: %w", err)
@@ -499,7 +532,7 @@ func (a Attacker) describeWithRetry(ctx context.Context, client *gortsplib.Clien
 
 		var badStatus liberrors.ErrClientBadStatusCode
 		if errors.As(err, &badStatus) && badStatus.Code == base.StatusServiceUnavailable {
-			a.reporter.Debug(cameradar.StepValidateStreams, fmt.Sprintf("DESCRIBE %s RTSP/1.0 > %d (retrying)", stream, badStatus.Code))
+			a.reporter.Debug(step, fmt.Sprintf("DESCRIBE %s RTSP/1.0 > %d (retrying)", stream, badStatus.Code))
 			select {
 			case <-ctx.Done():
 				return nil, nil, ctx.Err()

--- a/internal/attack/attacker_test.go
+++ b/internal/attack/attacker_test.go
@@ -401,6 +401,76 @@ func TestAttacker_Attack_Framecheck_RechecksCredentialFalsePositives(t *testing.
 	assert.True(t, got[0].Available)
 }
 
+func TestAttacker_Attack_Framecheck_FallsBackToTCPForRouteProbe(t *testing.T) {
+	reporter := &recordingReporter{}
+
+	addr, port := startRTSPServer(t, rtspServerConfig{
+		allowedRoute:      "stream",
+		requireAuth:       false,
+		authMethod:        headers.AuthMethodBasic,
+		sendFrames:        true,
+		sendFramesTCPOnly: true,
+	})
+
+	dict := testDictionary{
+		routes: []string{"stream"},
+	}
+
+	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, reporter)
+	require.NoError(t, err)
+
+	streams := []cameradar.Stream{{
+		Address: addr,
+		Port:    port,
+	}}
+
+	got, err := attacker.Attack(t.Context(), streams)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.True(t, got[0].RouteFound)
+	assert.Equal(t, []string{"stream"}, got[0].Routes)
+	assert.True(t, got[0].Available)
+	assert.True(t, reporter.HasDebugContaining("Frame probe succeeded"))
+}
+
+func TestAttacker_Attack_Framecheck_FallsBackToTCPForCredentialProbe(t *testing.T) {
+	addr, port := startRTSPServer(t, rtspServerConfig{
+		allowedRoute:              "stream",
+		requireAuth:               true,
+		describeAcceptInvalidAuth: true,
+		username:                  "user",
+		password:                  "pass",
+		authMethod:                headers.AuthMethodBasic,
+		sendFrames:                true,
+		sendFramesTCPOnly:         true,
+	})
+
+	dict := testDictionary{
+		routes:    []string{"stream"},
+		usernames: []string{"user"},
+		passwords: []string{"wrong", "pass"},
+	}
+
+	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, ui.NopReporter{})
+	require.NoError(t, err)
+
+	streams := []cameradar.Stream{{
+		Address: addr,
+		Port:    port,
+	}}
+
+	got, err := attacker.Attack(t.Context(), streams)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.True(t, got[0].RouteFound)
+	assert.True(t, got[0].CredentialsFound)
+	assert.Equal(t, "user", got[0].Username)
+	assert.Equal(t, "pass", got[0].Password)
+	assert.True(t, got[0].Available)
+}
+
 func TestAttacker_Attack_Framecheck_TreatsNoPacketAsFalsePositive(t *testing.T) {
 	reporter := &recordingReporter{}
 

--- a/internal/attack/attacker_test.go
+++ b/internal/attack/attacker_test.go
@@ -39,7 +39,7 @@ func TestNew(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			attacker, err := attack.New(test.dict, 10*time.Millisecond, time.Second, ui.NopReporter{})
+			attacker, err := attack.New(test.dict, 10*time.Millisecond, time.Second, false, ui.NopReporter{})
 			test.wantErr(t, err)
 			if err != nil {
 				assert.NotNil(t, attacker)
@@ -65,7 +65,7 @@ func TestAttacker_Attack_BasicAuth(t *testing.T) {
 
 	testInterval := time.Millisecond
 	testRequestTimeout := time.Second
-	attacker, err := attack.New(dict, testInterval, testRequestTimeout, ui.NopReporter{})
+	attacker, err := attack.New(dict, testInterval, testRequestTimeout, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -140,7 +140,7 @@ func TestAttacker_Attack_AuthVariants(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			addr, port := startRTSPServer(t, test.config)
 
-			attacker, err := attack.New(test.dict, 0, time.Second, ui.NopReporter{})
+			attacker, err := attack.New(test.dict, 0, time.Second, false, ui.NopReporter{})
 			require.NoError(t, err)
 
 			streams := []cameradar.Stream{{
@@ -165,7 +165,7 @@ func TestAttacker_Attack_AuthVariants(t *testing.T) {
 }
 
 func TestAttacker_Attack_ValidationErrors(t *testing.T) {
-	attacker, err := attack.New(testDictionary{routes: []string{"stream"}}, 0, time.Second, ui.NopReporter{})
+	attacker, err := attack.New(testDictionary{routes: []string{"stream"}}, 0, time.Second, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -204,7 +204,7 @@ func TestAttacker_Attack_ReturnsErrorWhenRouteMissing(t *testing.T) {
 		passwords: []string{"pass"},
 	}
 
-	attacker, err := attack.New(dict, 0, time.Second, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, time.Second, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -234,7 +234,7 @@ func TestAttacker_Attack_ReturnsErrorWhenCredentialsMissing(t *testing.T) {
 		passwords: []string{"wrong"},
 	}
 
-	attacker, err := attack.New(dict, 0, time.Second, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, time.Second, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -268,7 +268,7 @@ func TestAttacker_Attack_CredentialAttemptFails(t *testing.T) {
 		passwords: []string{"pass"},
 	}
 
-	attacker, err := attack.New(dict, 0, time.Second, reporter)
+	attacker, err := attack.New(dict, 0, time.Second, false, reporter)
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -292,7 +292,7 @@ func TestAttacker_Attack_AllowsDummyRoute(t *testing.T) {
 
 	dict := testDictionary{}
 
-	attacker, err := attack.New(dict, 0, time.Second, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, time.Second, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -320,7 +320,7 @@ func TestAttacker_Attack_ValidationFailsWhenSetupErrors(t *testing.T) {
 		routes: []string{"stream"},
 	}
 
-	attacker, err := attack.New(dict, 0, time.Second, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, time.Second, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -333,6 +333,72 @@ func TestAttacker_Attack_ValidationFailsWhenSetupErrors(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.False(t, got[0].Available)
 	assert.True(t, got[0].RouteFound)
+}
+
+func TestAttacker_Attack_VerifyRTSP200_RechecksRouteFalsePositives(t *testing.T) {
+	addr, port := startRTSPServer(t, rtspServerConfig{
+		allowedRoute:     "stream",
+		describeAllowAll: true,
+		requireAuth:      false,
+		authMethod:       headers.AuthMethodBasic,
+		sendFrames:       true,
+	})
+
+	dict := testDictionary{
+		routes: []string{"stream"},
+	}
+
+	attacker, err := attack.New(dict, 0, 500*time.Millisecond, true, ui.NopReporter{})
+	require.NoError(t, err)
+
+	streams := []cameradar.Stream{{
+		Address: addr,
+		Port:    port,
+	}}
+
+	got, err := attacker.Attack(t.Context(), streams)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.True(t, got[0].RouteFound)
+	assert.Equal(t, []string{"stream"}, got[0].Routes)
+	assert.True(t, got[0].Available)
+}
+
+func TestAttacker_Attack_VerifyRTSP200_RechecksCredentialFalsePositives(t *testing.T) {
+	addr, port := startRTSPServer(t, rtspServerConfig{
+		allowedRoute:              "stream",
+		requireAuth:               true,
+		describeAcceptInvalidAuth: true,
+		username:                  "user",
+		password:                  "pass",
+		authMethod:                headers.AuthMethodBasic,
+		sendFrames:                true,
+	})
+
+	dict := testDictionary{
+		routes:    []string{"stream"},
+		usernames: []string{"user"},
+		passwords: []string{"wrong", "pass"},
+	}
+
+	attacker, err := attack.New(dict, 0, 500*time.Millisecond, true, ui.NopReporter{})
+	require.NoError(t, err)
+
+	streams := []cameradar.Stream{{
+		Address: addr,
+		Port:    port,
+	}}
+
+	got, err := attacker.Attack(t.Context(), streams)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.True(t, got[0].RouteFound)
+	assert.True(t, got[0].CredentialsFound)
+	assert.Equal(t, "user", got[0].Username)
+	assert.Equal(t, "pass", got[0].Password)
+	assert.True(t, got[0].Available)
 }
 
 type testDictionary struct {

--- a/internal/attack/attacker_test.go
+++ b/internal/attack/attacker_test.go
@@ -335,7 +335,7 @@ func TestAttacker_Attack_ValidationFailsWhenSetupErrors(t *testing.T) {
 	assert.True(t, got[0].RouteFound)
 }
 
-func TestAttacker_Attack_VerifyRTSP200_RechecksRouteFalsePositives(t *testing.T) {
+func TestAttacker_Attack_Framecheck_RechecksRouteFalsePositives(t *testing.T) {
 	addr, port := startRTSPServer(t, rtspServerConfig{
 		allowedRoute:     "stream",
 		describeAllowAll: true,
@@ -365,7 +365,7 @@ func TestAttacker_Attack_VerifyRTSP200_RechecksRouteFalsePositives(t *testing.T)
 	assert.True(t, got[0].Available)
 }
 
-func TestAttacker_Attack_VerifyRTSP200_RechecksCredentialFalsePositives(t *testing.T) {
+func TestAttacker_Attack_Framecheck_RechecksCredentialFalsePositives(t *testing.T) {
 	addr, port := startRTSPServer(t, rtspServerConfig{
 		allowedRoute:              "stream",
 		requireAuth:               true,
@@ -399,6 +399,39 @@ func TestAttacker_Attack_VerifyRTSP200_RechecksCredentialFalsePositives(t *testi
 	assert.Equal(t, "user", got[0].Username)
 	assert.Equal(t, "pass", got[0].Password)
 	assert.True(t, got[0].Available)
+}
+
+func TestAttacker_Attack_Framecheck_TreatsNoPacketAsFalsePositive(t *testing.T) {
+	reporter := &recordingReporter{}
+
+	addr, port := startRTSPServer(t, rtspServerConfig{
+		allowedRoute:     "stream",
+		describeAllowAll: true,
+		requireAuth:      false,
+		authMethod:       headers.AuthMethodBasic,
+		sendFrames:       false,
+	})
+
+	dict := testDictionary{
+		routes: []string{"stream"},
+	}
+
+	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, reporter)
+	require.NoError(t, err)
+
+	streams := []cameradar.Stream{{
+		Address: addr,
+		Port:    port,
+	}}
+
+	got, err := attacker.Attack(t.Context(), streams)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.False(t, got[0].RouteFound)
+	assert.Empty(t, got[0].Routes)
+	assert.False(t, got[0].Available)
+	assert.True(t, reporter.HasDebugContaining("no RTP packet was received"))
 }
 
 type testDictionary struct {

--- a/internal/attack/attacker_test.go
+++ b/internal/attack/attacker_test.go
@@ -504,6 +504,76 @@ func TestAttacker_Attack_Framecheck_TreatsNoPacketAsFalsePositive(t *testing.T) 
 	assert.True(t, reporter.HasDebugContaining("no RTP packet was received"))
 }
 
+func TestAttacker_Attack_Framecheck_TreatsNoMediasAsFalsePositive(t *testing.T) {
+	reporter := &recordingReporter{}
+
+	addr, port := startRTSPServer(t, rtspServerConfig{
+		allowedRoute:        "stream",
+		requireAuth:         false,
+		authMethod:          headers.AuthMethodBasic,
+		describeNoMediaCall: 2,
+		describeStatusSequence: []base.StatusCode{
+			base.StatusOK,
+			base.StatusOK,
+		},
+	})
+
+	dict := testDictionary{}
+
+	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, reporter)
+	require.NoError(t, err)
+
+	streams := []cameradar.Stream{{
+		Address: addr,
+		Port:    port,
+	}}
+
+	got, err := attacker.Attack(t.Context(), streams)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "validating streams")
+	require.Len(t, got, 1)
+
+	assert.False(t, got[0].RouteFound)
+	assert.Empty(t, got[0].Routes)
+	assert.False(t, got[0].Available)
+	assert.True(t, reporter.HasDebugContaining("DESCRIBE returned no media tracks"))
+	assert.False(t, reporter.HasDebugContaining("no RTP packet was received"))
+}
+
+func TestAttacker_Attack_Framecheck_LogsDescribeRetryWithCurrentStep(t *testing.T) {
+	reporter := &recordingReporter{}
+
+	addr, port := startRTSPServer(t, rtspServerConfig{
+		allowAll:   true,
+		authMethod: headers.AuthMethodBasic,
+		sendFrames: true,
+		describeStatusSequence: []base.StatusCode{
+			base.StatusOK,
+			base.StatusServiceUnavailable,
+			base.StatusOK,
+		},
+	})
+
+	dict := testDictionary{}
+
+	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, reporter)
+	require.NoError(t, err)
+
+	streams := []cameradar.Stream{{
+		Address: addr,
+		Port:    port,
+	}}
+
+	got, err := attacker.Attack(t.Context(), streams)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	assert.True(t, got[0].RouteFound)
+	assert.True(t, got[0].Available)
+	assert.True(t, reporter.HasDebugForStepContaining(cameradar.StepAttackRoutes, "(retrying)"))
+	assert.False(t, reporter.HasDebugForStepContaining(cameradar.StepValidateStreams, "(retrying)"))
+}
+
 type testDictionary struct {
 	routes    []string
 	usernames []string
@@ -525,6 +595,7 @@ func (d testDictionary) Passwords() []string {
 type recordingReporter struct {
 	mu            sync.Mutex
 	debugMessages []string
+	debugSteps    []cameradar.Step
 }
 
 func (r *recordingReporter) Start(cameradar.Step, string) {}
@@ -533,9 +604,10 @@ func (r *recordingReporter) Done(cameradar.Step, string) {}
 
 func (r *recordingReporter) Progress(cameradar.Step, string) {}
 
-func (r *recordingReporter) Debug(_ cameradar.Step, message string) {
+func (r *recordingReporter) Debug(step cameradar.Step, message string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.debugSteps = append(r.debugSteps, step)
 	r.debugMessages = append(r.debugMessages, message)
 }
 
@@ -553,5 +625,18 @@ func (r *recordingReporter) HasDebugContaining(value string) bool {
 			return true
 		}
 	}
+	return false
+}
+
+func (r *recordingReporter) HasDebugForStepContaining(step cameradar.Step, value string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for idx, message := range r.debugMessages {
+		if r.debugSteps[idx] == step && strings.Contains(message, value) {
+			return true
+		}
+	}
+
 	return false
 }

--- a/internal/attack/detect_auth_test.go
+++ b/internal/attack/detect_auth_test.go
@@ -176,7 +176,7 @@ func TestDetectAuthMethod(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			addr, port := startRTSPProbeServer(t, test.statusCode, test.headers)
 
-			attacker, err := New(testDictionary{}, 0, time.Second, ui.NopReporter{})
+			attacker, err := New(testDictionary{}, 0, time.Second, false, ui.NopReporter{})
 			require.NoError(t, err)
 
 			stream := cameradar.Stream{
@@ -202,7 +202,7 @@ func TestDetectAuthMethod_HTTPTunnel_NonFatal(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			attacker, err := New(testDictionary{}, 0, time.Second, ui.NopReporter{})
+			attacker, err := New(testDictionary{}, 0, time.Second, false, ui.NopReporter{})
 			require.NoError(t, err)
 
 			stream := cameradar.Stream{
@@ -223,7 +223,7 @@ func TestDetectAuthMethod_RTSPS(t *testing.T) {
 		"WWW-Authenticate": headers.Authenticate{Method: headers.AuthMethodBasic, Realm: "cam"}.Marshal(),
 	})
 
-	attacker, err := New(testDictionary{}, 0, time.Second, ui.NopReporter{})
+	attacker, err := New(testDictionary{}, 0, time.Second, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	stream := cameradar.Stream{

--- a/internal/attack/rtsp_test.go
+++ b/internal/attack/rtsp_test.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bluenviron/gortsplib/v5"
 	"github.com/bluenviron/gortsplib/v5/pkg/auth"
@@ -14,35 +15,46 @@ import (
 	"github.com/bluenviron/gortsplib/v5/pkg/format"
 	"github.com/bluenviron/gortsplib/v5/pkg/headers"
 	"github.com/bluenviron/gortsplib/v5/pkg/liberrors"
+	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
 )
 
 type rtspServerConfig struct {
-	allowAll     bool
-	allowedRoute string
-	requireAuth  bool
-	username     string
-	password     string
-	authMethod   headers.AuthMethod
-	authHeader   base.HeaderValue
-	failOnAuth   bool
-	setupStatus  base.StatusCode
+	allowAll                  bool
+	describeAllowAll          bool
+	allowedRoute              string
+	requireAuth               bool
+	describeIgnoreAuth        bool
+	describeAcceptInvalidAuth bool
+	username                  string
+	password                  string
+	authMethod                headers.AuthMethod
+	authHeader                base.HeaderValue
+	failOnAuth                bool
+	setupStatus               base.StatusCode
+	playStatus                base.StatusCode
+	sendFrames                bool
 }
 
 type testServerHandler struct {
-	stream       *gortsplib.ServerStream
-	allowAll     bool
-	allowedRoute string
-	requireAuth  bool
-	username     string
-	password     string
-	authHeader   base.HeaderValue
-	failOnAuth   bool
-	setupStatus  base.StatusCode
+	stream                    *gortsplib.ServerStream
+	allowAll                  bool
+	describeAllowAll          bool
+	allowedRoute              string
+	requireAuth               bool
+	describeIgnoreAuth        bool
+	describeAcceptInvalidAuth bool
+	username                  string
+	password                  string
+	authHeader                base.HeaderValue
+	failOnAuth                bool
+	setupStatus               base.StatusCode
+	playStatus                base.StatusCode
+	sendFrames                bool
 }
 
 func (h *testServerHandler) OnDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx) (*base.Response, *gortsplib.ServerStream, error) {
-	if !h.routeAllowed(ctx.Path) {
+	if !h.describeRouteAllowed(ctx.Path) {
 		return &base.Response{StatusCode: base.StatusNotFound}, nil, nil
 	}
 
@@ -51,6 +63,11 @@ func (h *testServerHandler) OnDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx
 	}
 
 	if h.requireAuth && !ctx.Conn.VerifyCredentials(ctx.Request, h.username, h.password) {
+		authorization := ctx.Request.Header["Authorization"]
+		if h.describeIgnoreAuth || (h.describeAcceptInvalidAuth && len(authorization) > 0) {
+			return &base.Response{StatusCode: base.StatusOK}, h.stream, nil
+		}
+
 		return &base.Response{
 			StatusCode: base.StatusUnauthorized,
 			Header: base.Header{
@@ -84,22 +101,82 @@ func (h *testServerHandler) OnSetup(ctx *gortsplib.ServerHandlerOnSetupCtx) (*ba
 	return &base.Response{StatusCode: status}, h.stream, nil
 }
 
+func (h *testServerHandler) OnPlay(ctx *gortsplib.ServerHandlerOnPlayCtx) (*base.Response, error) {
+	if !h.routeAllowed(ctx.Path) {
+		return &base.Response{StatusCode: base.StatusNotFound}, nil
+	}
+
+	if h.requireAuth && !ctx.Conn.VerifyCredentials(ctx.Request, h.username, h.password) {
+		return &base.Response{
+			StatusCode: base.StatusUnauthorized,
+			Header: base.Header{
+				"WWW-Authenticate": h.authHeader,
+			},
+		}, liberrors.ErrServerAuth{}
+	}
+
+	status := base.StatusOK
+	if h.playStatus != 0 {
+		status = h.playStatus
+	}
+
+	if status == base.StatusOK && h.sendFrames {
+		h.emitFrame()
+	}
+
+	return &base.Response{StatusCode: status}, nil
+}
+
 func (h *testServerHandler) routeAllowed(path string) bool {
 	path = strings.TrimLeft(path, "/")
 	return h.allowAll || path == h.allowedRoute
+}
+
+func (h *testServerHandler) describeRouteAllowed(path string) bool {
+	if h.describeAllowAll {
+		return true
+	}
+
+	return h.routeAllowed(path)
+}
+
+func (h *testServerHandler) emitFrame() {
+	if h.stream == nil || h.stream.Desc == nil || len(h.stream.Desc.Medias) == 0 {
+		return
+	}
+
+	media := h.stream.Desc.Medias[0]
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_ = h.stream.WritePacketRTP(media, &rtp.Packet{
+			Header: rtp.Header{
+				Version:        2,
+				PayloadType:    96,
+				SequenceNumber: 1,
+				Timestamp:      90_000,
+				SSRC:           1,
+			},
+			Payload: []byte{0x05, 0x01},
+		})
+	}()
 }
 
 func startRTSPServer(t *testing.T, cfg rtspServerConfig) (netip.Addr, uint16) {
 	t.Helper()
 
 	handler := &testServerHandler{
-		allowAll:     cfg.allowAll,
-		allowedRoute: cfg.allowedRoute,
-		requireAuth:  cfg.requireAuth,
-		username:     cfg.username,
-		password:     cfg.password,
-		failOnAuth:   cfg.failOnAuth,
-		setupStatus:  cfg.setupStatus,
+		allowAll:                  cfg.allowAll,
+		describeAllowAll:          cfg.describeAllowAll,
+		allowedRoute:              cfg.allowedRoute,
+		requireAuth:               cfg.requireAuth,
+		describeIgnoreAuth:        cfg.describeIgnoreAuth,
+		describeAcceptInvalidAuth: cfg.describeAcceptInvalidAuth,
+		username:                  cfg.username,
+		password:                  cfg.password,
+		failOnAuth:                cfg.failOnAuth,
+		setupStatus:               cfg.setupStatus,
+		playStatus:                cfg.playStatus,
+		sendFrames:                cfg.sendFrames,
 	}
 
 	if len(cfg.authHeader) > 0 {

--- a/internal/attack/rtsp_test.go
+++ b/internal/attack/rtsp_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/netip"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const describeNoMediaSDP = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=No Media\r\nt=0 0\r\n"
+
 type rtspServerConfig struct {
 	allowAll                  bool
 	describeAllowAll          bool
@@ -26,6 +29,9 @@ type rtspServerConfig struct {
 	requireAuth               bool
 	describeIgnoreAuth        bool
 	describeAcceptInvalidAuth bool
+	describeReturnNoStream    bool
+	describeNoMediaCall       int
+	describeStatusSequence    []base.StatusCode
 	username                  string
 	password                  string
 	authMethod                headers.AuthMethod
@@ -45,6 +51,12 @@ type testServerHandler struct {
 	requireAuth               bool
 	describeIgnoreAuth        bool
 	describeAcceptInvalidAuth bool
+	describeReturnNoStream    bool
+	describeNoMediaCall       int
+	describeStatusSequence    []base.StatusCode
+	describeStatusIndex       int
+	describeCallCount         int
+	describeStatusMu          sync.Mutex
 	username                  string
 	password                  string
 	authHeader                base.HeaderValue
@@ -56,6 +68,15 @@ type testServerHandler struct {
 }
 
 func (h *testServerHandler) OnDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx) (*base.Response, *gortsplib.ServerStream, error) {
+	describeCall, status, ok := h.nextDescribePlan()
+	if ok {
+		if status == base.StatusOK {
+			return h.describeSuccessResponse(describeCall)
+		}
+
+		return &base.Response{StatusCode: status}, nil, nil
+	}
+
 	if !h.describeRouteAllowed(ctx.Path) {
 		return &base.Response{StatusCode: base.StatusNotFound}, nil, nil
 	}
@@ -67,7 +88,7 @@ func (h *testServerHandler) OnDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx
 	if h.requireAuth && !ctx.Conn.VerifyCredentials(ctx.Request, h.username, h.password) {
 		authorization := ctx.Request.Header["Authorization"]
 		if h.describeIgnoreAuth || (h.describeAcceptInvalidAuth && len(authorization) > 0) {
-			return &base.Response{StatusCode: base.StatusOK}, h.stream, nil
+			return h.describeSuccessResponse(describeCall)
 		}
 
 		return &base.Response{
@@ -78,7 +99,38 @@ func (h *testServerHandler) OnDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx
 		}, nil, liberrors.ErrServerAuth{}
 	}
 
-	return &base.Response{StatusCode: base.StatusOK}, h.stream, nil
+	return h.describeSuccessResponse(describeCall)
+}
+
+func (h *testServerHandler) describeSuccessResponse(describeCall int) (*base.Response, *gortsplib.ServerStream, error) {
+	returnNoStream := h.describeReturnNoStream || (h.describeNoMediaCall > 0 && h.describeNoMediaCall == describeCall)
+	if !returnNoStream {
+		return &base.Response{StatusCode: base.StatusOK}, h.stream, nil
+	}
+
+	return &base.Response{
+		StatusCode: base.StatusOK,
+		Header: base.Header{
+			"Content-Type": base.HeaderValue{"application/sdp"},
+		},
+		Body: []byte(describeNoMediaSDP),
+	}, nil, nil
+}
+
+func (h *testServerHandler) nextDescribePlan() (int, base.StatusCode, bool) {
+	h.describeStatusMu.Lock()
+	defer h.describeStatusMu.Unlock()
+	h.describeCallCount++
+	describeCall := h.describeCallCount
+
+	if h.describeStatusIndex >= len(h.describeStatusSequence) {
+		return describeCall, 0, false
+	}
+
+	status := h.describeStatusSequence[h.describeStatusIndex]
+	h.describeStatusIndex++
+
+	return describeCall, status, true
 }
 
 func (h *testServerHandler) OnSetup(ctx *gortsplib.ServerHandlerOnSetupCtx) (*base.Response, *gortsplib.ServerStream, error) {
@@ -192,6 +244,9 @@ func startRTSPServer(t *testing.T, cfg rtspServerConfig) (netip.Addr, uint16) {
 		requireAuth:               cfg.requireAuth,
 		describeIgnoreAuth:        cfg.describeIgnoreAuth,
 		describeAcceptInvalidAuth: cfg.describeAcceptInvalidAuth,
+		describeReturnNoStream:    cfg.describeReturnNoStream,
+		describeNoMediaCall:       cfg.describeNoMediaCall,
+		describeStatusSequence:    append([]base.StatusCode(nil), cfg.describeStatusSequence...),
 		username:                  cfg.username,
 		password:                  cfg.password,
 		failOnAuth:                cfg.failOnAuth,

--- a/internal/attack/rtsp_test.go
+++ b/internal/attack/rtsp_test.go
@@ -34,6 +34,7 @@ type rtspServerConfig struct {
 	setupStatus               base.StatusCode
 	playStatus                base.StatusCode
 	sendFrames                bool
+	sendFramesTCPOnly         bool
 }
 
 type testServerHandler struct {
@@ -51,6 +52,7 @@ type testServerHandler struct {
 	setupStatus               base.StatusCode
 	playStatus                base.StatusCode
 	sendFrames                bool
+	sendFramesTCPOnly         bool
 }
 
 func (h *testServerHandler) OnDescribe(ctx *gortsplib.ServerHandlerOnDescribeCtx) (*base.Response, *gortsplib.ServerStream, error) {
@@ -120,11 +122,30 @@ func (h *testServerHandler) OnPlay(ctx *gortsplib.ServerHandlerOnPlayCtx) (*base
 		status = h.playStatus
 	}
 
-	if status == base.StatusOK && h.sendFrames {
+	if status == base.StatusOK && h.shouldSendFrames(ctx.Session) {
 		h.emitFrame()
 	}
 
 	return &base.Response{StatusCode: status}, nil
+}
+
+func (h *testServerHandler) shouldSendFrames(session *gortsplib.ServerSession) bool {
+	if !h.sendFrames {
+		return false
+	}
+	if !h.sendFramesTCPOnly {
+		return true
+	}
+	if session == nil {
+		return false
+	}
+
+	transport := session.Transport()
+	if transport == nil {
+		return false
+	}
+
+	return transport.Protocol == gortsplib.ProtocolTCP
 }
 
 func (h *testServerHandler) routeAllowed(path string) bool {
@@ -177,6 +198,7 @@ func startRTSPServer(t *testing.T, cfg rtspServerConfig) (netip.Addr, uint16) {
 		setupStatus:               cfg.setupStatus,
 		playStatus:                cfg.playStatus,
 		sendFrames:                cfg.sendFrames,
+		sendFramesTCPOnly:         cfg.sendFramesTCPOnly,
 	}
 
 	if len(cfg.authHeader) > 0 {


### PR DESCRIPTION
## Goal of this PR

This PR adds a new `framecheck` option, that significantly slows down attacks but prevents false positives from cameras that do not follow the RTSP RFC correctly.

When framecheck is enabled, every single 200 OK response in the attack phase is followed by a probe that attempts to grab a frame from the stream. If none is successfully fetched, the attack resumes instead of assuming the Camera is available at that path/those credentials.

Fixes #438

## How did I test it?

For now only unit tests unfortunately, since I do not have such cameras available for testing.
Hoping that @Vickac2024 will be able to help me test this on their cameras :)