### PR TITLE
feat: encode credentials in M3U playlist URLs

### DIFF
--- a/internal/output/m3u.go
+++ b/internal/output/m3u.go
@@ -2,6 +2,8 @@ package output
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -114,12 +116,14 @@ func formatStreamLabel(stream cameradar.Stream) string {
 func formatRTSPURL(stream cameradar.Stream) string {
 	path := "/" + strings.TrimLeft(strings.TrimSpace(stream.Route()), "/")
 
-	credentials := ""
+	u := &url.URL{
+		Scheme: stream.RTSPScheme(),
+		Host:   net.JoinHostPort(stream.Address.String(), strconv.FormatUint(uint64(stream.Port), 10)),
+		Path:   path,
+	}
 	if stream.CredentialsFound && (stream.Username != "" || stream.Password != "") {
-		credentials = stream.Username + ":" + stream.Password + "@"
+		u.User = url.UserPassword(stream.Username, stream.Password)
 	}
 
-	scheme := stream.RTSPScheme()
-
-	return fmt.Sprintf("%s://%s%s:%s%s", scheme, credentials, stream.Address.String(), strconv.FormatUint(uint64(stream.Port), 10), path)
+	return u.String()
 }

--- a/internal/output/m3u_test.go
+++ b/internal/output/m3u_test.go
@@ -1,4 +1,4 @@
-package output
+package output_test
 
 import (
 	"net/netip"
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/Ullaakut/cameradar/v6"
+	"github.com/Ullaakut/cameradar/v6/internal/output"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +22,7 @@ func TestBuildM3U_EncodesCredentials(t *testing.T) {
 		CredentialsFound: true,
 	}
 
-	playlist := BuildM3U([]cameradar.Stream{stream})
+	playlist := output.BuildM3U([]cameradar.Stream{stream})
 
 	var rtspLine string
 	for _, line := range strings.Split(playlist, "\n") {
@@ -33,9 +35,9 @@ func TestBuildM3U_EncodesCredentials(t *testing.T) {
 
 	u, err := url.Parse(rtspLine)
 	require.NoError(t, err)
-	require.Equal(t, "admin", u.User.Username())
+	assert.Equal(t, "admin", u.User.Username())
 	pass, _ := u.User.Password()
-	require.Equal(t, "pass/word", pass)
-	require.Equal(t, "192.0.2.10:554", u.Host)
-	require.Equal(t, "/stream", u.Path)
+	assert.Equal(t, "pass/word", pass)
+	assert.Equal(t, "192.0.2.10:554", u.Host)
+	assert.Equal(t, "/stream", u.Path)
 }

--- a/internal/output/m3u_test.go
+++ b/internal/output/m3u_test.go
@@ -1,0 +1,41 @@
+package output
+
+import (
+	"net/netip"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Ullaakut/cameradar/v6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildM3U_EncodesCredentials(t *testing.T) {
+	stream := cameradar.Stream{
+		Address:          netip.MustParseAddr("192.0.2.10"),
+		Port:             554,
+		Routes:           []string{"stream"},
+		Username:         "admin",
+		Password:         "pass/word",
+		CredentialsFound: true,
+	}
+
+	playlist := BuildM3U([]cameradar.Stream{stream})
+
+	var rtspLine string
+	for _, line := range strings.Split(playlist, "\n") {
+		if strings.HasPrefix(line, "rtsp") {
+			rtspLine = line
+			break
+		}
+	}
+	require.NotEmpty(t, rtspLine)
+
+	u, err := url.Parse(rtspLine)
+	require.NoError(t, err)
+	require.Equal(t, "admin", u.User.Username())
+	pass, _ := u.User.Password()
+	require.Equal(t, "pass/word", pass)
+	require.Equal(t, "192.0.2.10:554", u.Host)
+	require.Equal(t, "/stream", u.Path)
+}


### PR DESCRIPTION
`formatRTSPURL` in `internal/output/m3u.go` builds the RTSP URL by string concatenation, so a username or password containing reserved characters (`/`, space, `@`) produces a malformed URL. For example a password `pass/word` yields `rtsp://admin:pass/word@192.0.2.10:554/stream`, which media players and Go's own `url.Parse` reject (`invalid port ":pass" after host`).

The canonical `Stream.String()` already builds the URL with `net/url` and `url.UserPassword`. This change makes `formatRTSPURL` do the same, so the two paths agree and credentials are encoded correctly.

Added `TestBuildM3U_EncodesCredentials`, which fails on the current code and passes with the change. `go vet` and the output package tests pass.