### PR TITLE
bracket IPv6 hosts in summary output URLs

### DIFF
--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -125,12 +126,18 @@ func formatRTSPURL(stream cameradar.Stream) string {
 	}
 
 	scheme := stream.RTSPScheme()
+	host := net.JoinHostPort(stream.Address.String(), strconv.FormatUint(uint64(stream.Port), 10))
 
-	return fmt.Sprintf("%s://%s%s:%d%s", scheme, credentials, stream.Address.String(), stream.Port, path)
+	return fmt.Sprintf("%s://%s%s%s", scheme, credentials, host, path)
 }
 
 func formatAdminPanelURL(stream cameradar.Stream) string {
-	return fmt.Sprintf("http://%s/", stream.Address.String())
+	// Bracket the host so IPv6 addresses form a valid URL.
+	host := stream.Address.String()
+	if stream.Address.Is6() {
+		host = "[" + host + "]"
+	}
+	return fmt.Sprintf("http://%s/", host)
 }
 
 func formatCredentials(stream cameradar.Stream) string {

--- a/internal/ui/summary_test.go
+++ b/internal/ui/summary_test.go
@@ -11,6 +11,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFormatSummaryIPv6BracketsHost(t *testing.T) {
+	streams := []cameradar.Stream{
+		{
+			Address:            netip.MustParseAddr("fe80::1"),
+			Port:               554,
+			Available:          true,
+			RouteFound:         true,
+			Routes:             []string{"stream"},
+			CredentialsFound:   true,
+			Username:           "user",
+			Password:           "pass",
+			AuthenticationType: cameradar.AuthBasic,
+		},
+	}
+
+	got := ui.FormatSummary(streams, nil)
+
+	// IPv6 hosts must be bracketed to form valid URLs.
+	assert.Contains(t, got, "RTSP URL: rtsp://user:pass@[fe80::1]:554/stream")
+	assert.Contains(t, got, "Admin panel: http://[fe80::1]/")
+}
+
 func TestFormatSummary(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
`formatRTSPURL` and `formatAdminPanelURL` in `internal/ui/summary.go` concatenate `stream.Address.String()` directly into the host position:

```go
fmt.Sprintf("%s://%s%s:%d%s", scheme, credentials, stream.Address.String(), stream.Port, path)
fmt.Sprintf("http://%s/", stream.Address.String())
```

For an IPv6 address (e.g. `fe80::1`) this yields malformed URLs (`rtsp://user:pass@fe80::1:554/stream`, `http://fe80::1/`); an IPv6 host in a URL must be bracketed (`[fe80::1]`). The other URL builders in the repo (m3u, stream.go) already use `net.JoinHostPort`, which brackets IPv6.

Fix uses `net.JoinHostPort` for the RTSP URL and brackets the IPv6 host for the admin panel. IPv4 output is unchanged. Added `TestFormatSummaryIPv6BracketsHost`; it fails on the current code and passes with the change.