### PR TITLE
fix(ui): percent-encode credentials in the summary RTSP URL

### DIFF
--- a/internal/output/m3u.go
+++ b/internal/output/m3u.go
@@ -2,8 +2,6 @@ package output
 
 import (
 	"fmt"
-	"net"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -92,7 +90,7 @@ func BuildM3U(streams []cameradar.Stream) string {
 	var builder strings.Builder
 	builder.WriteString("#EXTM3U\n")
 	for _, stream := range streams {
-		url := formatRTSPURL(stream)
+		url := stream.String()
 		if url == "" {
 			continue
 		}
@@ -111,19 +109,4 @@ func formatStreamLabel(stream cameradar.Stream) string {
 		return label
 	}
 	return label + " (" + stream.Device + ")"
-}
-
-func formatRTSPURL(stream cameradar.Stream) string {
-	path := "/" + strings.TrimLeft(strings.TrimSpace(stream.Route()), "/")
-
-	u := &url.URL{
-		Scheme: stream.RTSPScheme(),
-		Host:   net.JoinHostPort(stream.Address.String(), strconv.FormatUint(uint64(stream.Port), 10)),
-		Path:   path,
-	}
-	if stream.CredentialsFound && (stream.Username != "" || stream.Password != "") {
-		u.User = url.UserPassword(stream.Username, stream.Password)
-	}
-
-	return u.String()
 }

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -120,15 +121,16 @@ func formatStream(stream cameradar.Stream) string {
 func formatRTSPURL(stream cameradar.Stream) string {
 	path := "/" + strings.TrimLeft(strings.TrimSpace(stream.Route()), "/")
 
-	credentials := ""
+	u := &url.URL{
+		Scheme: stream.RTSPScheme(),
+		Host:   net.JoinHostPort(stream.Address.String(), strconv.FormatUint(uint64(stream.Port), 10)),
+		Path:   path,
+	}
 	if stream.Username != "" || stream.Password != "" {
-		credentials = stream.Username + ":" + stream.Password + "@"
+		u.User = url.UserPassword(stream.Username, stream.Password)
 	}
 
-	scheme := stream.RTSPScheme()
-	host := net.JoinHostPort(stream.Address.String(), strconv.FormatUint(uint64(stream.Port), 10))
-
-	return fmt.Sprintf("%s://%s%s%s", scheme, credentials, host, path)
+	return u.String()
 }
 
 func formatAdminPanelURL(stream cameradar.Stream) string {

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -2,8 +2,6 @@ package ui
 
 import (
 	"fmt"
-	"net"
-	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -107,7 +105,7 @@ func formatStream(stream cameradar.Stream) string {
 
 	if stream.RouteFound && (stream.CredentialsFound || stream.AuthenticationType == cameradar.AuthNone) {
 		builder.WriteString("  RTSP URL: ")
-		builder.WriteString(formatRTSPURL(stream))
+		builder.WriteString(stream.String())
 		builder.WriteString("\n")
 	}
 
@@ -116,21 +114,6 @@ func formatStream(stream cameradar.Stream) string {
 	builder.WriteString("\n")
 
 	return builder.String()
-}
-
-func formatRTSPURL(stream cameradar.Stream) string {
-	path := "/" + strings.TrimLeft(strings.TrimSpace(stream.Route()), "/")
-
-	u := &url.URL{
-		Scheme: stream.RTSPScheme(),
-		Host:   net.JoinHostPort(stream.Address.String(), strconv.FormatUint(uint64(stream.Port), 10)),
-		Path:   path,
-	}
-	if stream.Username != "" || stream.Password != "" {
-		u.User = url.UserPassword(stream.Username, stream.Password)
-	}
-
-	return u.String()
 }
 
 func formatAdminPanelURL(stream cameradar.Stream) string {

--- a/internal/ui/summary_test.go
+++ b/internal/ui/summary_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Ullaakut/cameradar/v6"
 	"github.com/Ullaakut/cameradar/v6/internal/ui"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormatSummaryIPv6BracketsHost(t *testing.T) {
@@ -174,19 +175,13 @@ func TestFormatSummaryEncodesCredentials(t *testing.T) {
 
 	const prefix = "RTSP URL: "
 	idx := strings.Index(got, prefix)
-	if idx < 0 {
-		t.Fatalf("summary missing RTSP URL line:\n%s", got)
-	}
+	require.GreaterOrEqual(t, idx, 0, "summary missing RTSP URL line:\n%s", got)
 	rest := got[idx+len(prefix):]
 	rawURL := strings.TrimSpace(rest[:strings.IndexByte(rest, '\n')])
 
 	u, err := url.Parse(rawURL)
-	if err != nil {
-		t.Fatalf("RTSP URL is not parseable: %q: %v", rawURL, err)
-	}
-	if u.User == nil {
-		t.Fatalf("RTSP URL has no userinfo: %q", rawURL)
-	}
+	require.NoError(t, err, "RTSP URL is not parseable: %q", rawURL)
+	require.NotNil(t, u.User, "RTSP URL has no userinfo: %q", rawURL)
 	pw, _ := u.User.Password()
 	assert.Equal(t, "ad@min", u.User.Username())
 	assert.Equal(t, "p@ss word", pw)

--- a/internal/ui/summary_test.go
+++ b/internal/ui/summary_test.go
@@ -3,6 +3,7 @@ package ui_test
 import (
 	"errors"
 	"net/netip"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -149,4 +150,44 @@ func TestFormatSummary(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFormatSummaryEncodesCredentials(t *testing.T) {
+	// The default credentials dictionary ships passwords with characters that
+	// are not URL-safe (for example "admin pass"). The summary RTSP URL must
+	// percent-encode them so it stays parseable.
+	streams := []cameradar.Stream{
+		{
+			Address:            netip.MustParseAddr("10.0.0.1"),
+			Port:               554,
+			Available:          true,
+			RouteFound:         true,
+			Routes:             []string{"stream"},
+			CredentialsFound:   true,
+			Username:           "ad@min",
+			Password:           "p@ss word",
+			AuthenticationType: cameradar.AuthBasic,
+		},
+	}
+
+	got := ui.FormatSummary(streams, nil)
+
+	const prefix = "RTSP URL: "
+	idx := strings.Index(got, prefix)
+	if idx < 0 {
+		t.Fatalf("summary missing RTSP URL line:\n%s", got)
+	}
+	rest := got[idx+len(prefix):]
+	rawURL := strings.TrimSpace(rest[:strings.IndexByte(rest, '\n')])
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("RTSP URL is not parseable: %q: %v", rawURL, err)
+	}
+	if u.User == nil {
+		t.Fatalf("RTSP URL has no userinfo: %q", rawURL)
+	}
+	pw, _ := u.User.Password()
+	assert.Equal(t, "ad@min", u.User.Username())
+	assert.Equal(t, "p@ss word", pw)
 }

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -555,7 +555,7 @@ func buildSummaryRows(streams []cameradar.Stream, visibility summaryVisibilitySt
 
 		rtspURL := emptyEntry
 		if visibility.showCredentials && stream.RouteFound && stream.CredentialsFound {
-			rtspURL = formatRTSPURL(stream)
+			rtspURL = stream.String()
 		}
 
 		authType := emptyEntry


### PR DESCRIPTION
Fixes #446.

`formatRTSPURL` in `internal/ui/summary.go` concatenated the username and password into the URL without encoding, so credentials containing characters such as a space, `@`, `:` or `#` produced a malformed, often unparseable RTSP URL. The default credentials dictionary ships passwords like `admin pass`, so this is hit in normal use.

The M3U output already builds the URL with `net/url` and `url.UserPassword` (#440); this applies the same approach to the summary/TUI path. Plain credentials render identically to before, so the existing IPv6 and mixed-stream tests are unchanged.

Added `TestFormatSummaryEncodesCredentials`, which asserts the URL is parseable and round-trips a username and password containing `@` and a space. It fails on the previous code and passes with the fix.