### PR TITLE
fix(dict): sanitize route lines when parsing dictionary

### DIFF
--- a/internal/dict/loader.go
+++ b/internal/dict/loader.go
@@ -127,7 +127,12 @@ func parseRoutes(reader io.ReadCloser) (routes, error) {
 	var routes routes
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
-		routes = append(routes, scanner.Text())
+		line := strings.TrimPrefix(scanner.Text(), "\ufeff")
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		routes = append(routes, line)
 	}
 
 	return routes, scanner.Err()

--- a/internal/dict/loader_test.go
+++ b/internal/dict/loader_test.go
@@ -155,6 +155,49 @@ func TestNew_Errors(t *testing.T) {
 	}
 }
 
+func TestNew_RoutesSanitization(t *testing.T) {
+	tempDir := t.TempDir()
+	credsPath := writeTempFile(t, tempDir, "creds.json", `{"usernames":["alice"],"passwords":["secret"]}`)
+
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name:    "strips BOM from first route",
+			content: "\ufeffstream\nother\n",
+			want:    []string{"stream", "other"},
+		},
+		{
+			name:    "skips leading, trailing and whitespace-only lines",
+			content: "\n\nstream\n   \nother\n\n",
+			want:    []string{"stream", "other"},
+		},
+		{
+			name:    "trims surrounding whitespace per line",
+			content: "  stream  \n\tother\t\n",
+			want:    []string{"stream", "other"},
+		},
+		{
+			name:    "handles CRLF line endings",
+			content: "stream\r\nother\r\n",
+			want:    []string{"stream", "other"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			routesPath := writeTempFile(t, tempDir, "routes-"+test.name, test.content)
+
+			got, err := dict.New(credsPath, routesPath)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.want, got.Routes())
+		})
+	}
+}
+
 func writeTempFile(t *testing.T, dir, name, content string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)


### PR DESCRIPTION
Fixes #448

`parseRoutes` appended every scanned line verbatim. A routes file with a UTF-8 BOM made the first custom route unmatchable (e.g. `﻿stream` instead of `stream`), and blank or whitespace-only lines became bogus empty-route probes.

This mirrors the targets loader: strip a BOM prefix, trim surrounding whitespace, and skip empty lines.

Added table-driven regression tests covering BOM stripping, blank/whitespace-only line skipping, per-line trimming, and CRLF endings.