### PR TITLE
fix(attack): keep scanning when a single camera is unreachable

### DIFF
--- a/cameradar.go
+++ b/cameradar.go
@@ -61,7 +61,7 @@ func (a *App) Run(ctx context.Context) error {
 	if err != nil {
 		wrapped := fmt.Errorf("discovering devices: %w", err)
 		a.reporter.Error(StepScan, wrapped)
-		a.reporter.Summary(streams, wrapped)
+		a.reporter.Summary(streams, nil)
 		return wrapped
 	}
 	a.reporter.Done(StepScan, "Scan complete")

--- a/cameradar_test.go
+++ b/cameradar_test.go
@@ -92,7 +92,7 @@ func TestApp_Run(t *testing.T) {
 			wantErrContains: "discovering devices",
 			wantErrorCalls:  1,
 			wantSummary:     streams,
-			wantSummaryErr:  "discovering devices",
+			wantSummaryErr:  "",
 		},
 		{
 			name: "attack error",

--- a/internal/attack/attacker.go
+++ b/internal/attack/attacker.go
@@ -69,12 +69,12 @@ func (a Attacker) Attack(ctx context.Context, targets []cameradar.Stream) ([]cam
 
 	// Each phase processes every target even when one camera errors, so a
 	// single unreachable host cannot drop results for the rest of the batch.
-	// The first non-cancellation error is remembered and surfaced after all
-	// phases have run, while healthy cameras still progress to validation.
-	var firstErr error
+	// Every non-cancellation error is aggregated and surfaced after all phases
+	// have run, while healthy cameras still progress to validation.
+	var errs error
 	record := func(err error) {
-		if err != nil && firstErr == nil {
-			firstErr = err
+		if err != nil {
+			errs = errors.Join(errs, err)
 		}
 	}
 
@@ -109,7 +109,7 @@ func (a Attacker) Attack(ctx context.Context, targets []cameradar.Stream) ([]cam
 		record(err)
 	}
 
-	return streams, firstErr
+	return streams, errs
 }
 
 func (a Attacker) attackRoutesPhase(ctx context.Context, targets []cameradar.Stream) ([]cameradar.Stream, error) {

--- a/internal/attack/attacker.go
+++ b/internal/attack/attacker.go
@@ -67,37 +67,49 @@ func (a Attacker) Attack(ctx context.Context, targets []cameradar.Stream) ([]cam
 		return nil, errors.New("no stream found")
 	}
 
+	// Each phase processes every target even when one camera errors, so a
+	// single unreachable host cannot drop results for the rest of the batch.
+	// The first non-cancellation error is remembered and surfaced after all
+	// phases have run, while healthy cameras still progress to validation.
+	var firstErr error
+	record := func(err error) {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
 	streams, err := a.attackRoutesPhase(ctx, targets)
-	if err != nil {
-		return streams, err
+	record(err)
+	if ctx.Err() != nil {
+		return streams, ctx.Err()
 	}
 
 	streams, err = a.detectAuthPhase(ctx, streams)
-	if err != nil {
-		return streams, err
+	record(err)
+	if ctx.Err() != nil {
+		return streams, ctx.Err()
 	}
 
 	streams, err = a.attackCredentialsPhase(ctx, streams)
-	if err != nil {
-		return streams, err
+	record(err)
+	if ctx.Err() != nil {
+		return streams, ctx.Err()
 	}
 
 	streams, err = a.validateStreamsPhase(ctx, streams)
-	if err != nil {
-		return streams, err
+	record(err)
+	if ctx.Err() != nil {
+		return streams, ctx.Err()
 	}
 
 	// Some cameras run an inaccurate version of the RTSP protocol which prioritizes 401 over 404.
 	// For these cameras, running another route attack solves the problem.
-	if !needsReattack(streams) {
-		return streams, nil
-	}
-	streams, err = a.reattackRoutes(ctx, streams)
-	if err != nil {
-		return streams, err
+	if needsReattack(streams) {
+		streams, err = a.reattackRoutes(ctx, streams)
+		record(err)
 	}
 
-	return streams, nil
+	return streams, firstErr
 }
 
 func (a Attacker) attackRoutesPhase(ctx context.Context, targets []cameradar.Stream) ([]cameradar.Stream, error) {

--- a/internal/attack/attacker.go
+++ b/internal/attack/attacker.go
@@ -69,44 +69,37 @@ func (a Attacker) Attack(ctx context.Context, targets []cameradar.Stream) ([]cam
 
 	// Each phase processes every target even when one camera errors, so a
 	// single unreachable host cannot drop results for the rest of the batch.
-	// Every non-cancellation error is aggregated and surfaced after all phases
-	// have run, while healthy cameras still progress to validation.
+	// Every phase error is aggregated and surfaced after all phases have run,
+	// while healthy cameras still progress to validation.
 	var errs error
-	record := func(err error) {
-		if err != nil {
-			errs = errors.Join(errs, err)
-		}
-	}
 
 	streams, err := a.attackRoutesPhase(ctx, targets)
-	record(err)
-	if ctx.Err() != nil {
-		return streams, ctx.Err()
+	if err != nil {
+		errs = errors.Join(errs, err)
 	}
 
 	streams, err = a.detectAuthPhase(ctx, streams)
-	record(err)
-	if ctx.Err() != nil {
-		return streams, ctx.Err()
+	if err != nil {
+		errs = errors.Join(errs, err)
 	}
 
 	streams, err = a.attackCredentialsPhase(ctx, streams)
-	record(err)
-	if ctx.Err() != nil {
-		return streams, ctx.Err()
+	if err != nil {
+		errs = errors.Join(errs, err)
 	}
 
 	streams, err = a.validateStreamsPhase(ctx, streams)
-	record(err)
-	if ctx.Err() != nil {
-		return streams, ctx.Err()
+	if err != nil {
+		errs = errors.Join(errs, err)
 	}
 
 	// Some cameras run an inaccurate version of the RTSP protocol which prioritizes 401 over 404.
 	// For these cameras, running another route attack solves the problem.
 	if needsReattack(streams) {
 		streams, err = a.reattackRoutes(ctx, streams)
-		record(err)
+		if err != nil {
+			errs = errors.Join(errs, err)
+		}
 	}
 
 	return streams, errs

--- a/internal/attack/attacker_test.go
+++ b/internal/attack/attacker_test.go
@@ -1,6 +1,8 @@
 package attack_test
 
 import (
+	"net"
+	"net/netip"
 	"strings"
 	"sync"
 	"testing"
@@ -281,6 +283,63 @@ func TestAttacker_Attack_CredentialAttemptFails(t *testing.T) {
 	assert.ErrorContains(t, err, "validating streams")
 	require.Len(t, got, 1)
 	assert.False(t, got[0].CredentialsFound)
+}
+
+func TestAttacker_Attack_UnreachableHostDoesNotDropOthers(t *testing.T) {
+	addr, port := startRTSPServer(t, rtspServerConfig{
+		allowedRoute: "stream",
+		requireAuth:  false,
+		authMethod:   headers.AuthMethodBasic,
+	})
+
+	deadAddr, deadPort := closedPort(t)
+
+	dict := testDictionary{
+		routes: []string{"stream"},
+	}
+
+	attacker, err := attack.New(dict, 0, 200*time.Millisecond, false, ui.NopReporter{})
+	require.NoError(t, err)
+
+	// The unreachable host is listed first so that, before the fix, its
+	// connection failure would cancel the shared context and abort the
+	// healthy camera too.
+	streams := []cameradar.Stream{
+		{Address: deadAddr, Port: deadPort},
+		{Address: addr, Port: port},
+	}
+
+	got, err := attacker.Attack(t.Context(), streams)
+	_ = err // a dead host may surface an error; the batch must still complete.
+	require.Len(t, got, 2)
+
+	var healthy *cameradar.Stream
+	for i := range got {
+		if got[i].Address == addr && got[i].Port == port {
+			healthy = &got[i]
+		}
+	}
+	require.NotNil(t, healthy, "healthy camera missing from results")
+	assert.True(t, healthy.RouteFound, "healthy camera should still find its route")
+	assert.True(t, healthy.Available, "healthy camera should still be available despite an unreachable peer")
+}
+
+func closedPort(t *testing.T) (netip.Addr, uint16) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	addr, ok := netip.AddrFromSlice(tcpAddr.IP.To4())
+	require.True(t, ok)
+
+	port := uint16(tcpAddr.Port)
+	require.NoError(t, listener.Close())
+
+	return addr, port
 }
 
 func TestAttacker_Attack_AllowsDummyRoute(t *testing.T) {

--- a/internal/attack/attacker_test.go
+++ b/internal/attack/attacker_test.go
@@ -324,6 +324,47 @@ func TestAttacker_Attack_UnreachableHostDoesNotDropOthers(t *testing.T) {
 	assert.True(t, healthy.Available, "healthy camera should still be available despite an unreachable peer")
 }
 
+func TestAttacker_Attack_AggregatesErrorsFromMultipleHosts(t *testing.T) {
+	healthyAddr, healthyPort := startRTSPServer(t, rtspServerConfig{
+		allowedRoute: "stream",
+		requireAuth:  false,
+		authMethod:   headers.AuthMethodBasic,
+	})
+
+	firstDeadAddr, firstDeadPort := closedPort(t)
+	secondDeadAddr, secondDeadPort := closedPort(t)
+
+	dict := testDictionary{
+		routes: []string{"stream"},
+	}
+
+	attacker, err := attack.New(dict, 0, 200*time.Millisecond, false, ui.NopReporter{})
+	require.NoError(t, err)
+
+	streams := []cameradar.Stream{
+		{Address: firstDeadAddr, Port: firstDeadPort},
+		{Address: healthyAddr, Port: healthyPort},
+		{Address: secondDeadAddr, Port: secondDeadPort},
+	}
+
+	got, err := attacker.Attack(t.Context(), streams)
+	require.Error(t, err)
+	require.Len(t, got, 3)
+
+	// The joined error must mention both unreachable hosts, not just the first.
+	assert.ErrorContains(t, err, firstDeadAddr.String())
+	assert.ErrorContains(t, err, secondDeadAddr.String())
+
+	var healthy *cameradar.Stream
+	for i := range got {
+		if got[i].Address == healthyAddr && got[i].Port == healthyPort {
+			healthy = &got[i]
+		}
+	}
+	require.NotNil(t, healthy, "healthy camera missing from results")
+	assert.True(t, healthy.Available, "healthy camera should stay available despite unreachable peers")
+}
+
 func closedPort(t *testing.T) (netip.Addr, uint16) {
 	t.Helper()
 

--- a/internal/attack/attacker_test.go
+++ b/internal/attack/attacker_test.go
@@ -309,8 +309,7 @@ func TestAttacker_Attack_UnreachableHostDoesNotDropOthers(t *testing.T) {
 		{Address: addr, Port: port},
 	}
 
-	got, err := attacker.Attack(t.Context(), streams)
-	_ = err // a dead host may surface an error; the batch must still complete.
+	got, _ := attacker.Attack(t.Context(), streams) // A dead host may surface an error, but the attack must still complete.
 	require.Len(t, got, 2)
 
 	var healthy *cameradar.Stream

--- a/internal/attack/workers.go
+++ b/internal/attack/workers.go
@@ -32,7 +32,7 @@ func runParallel(ctx context.Context, targets []cameradar.Stream, fn attackFn) (
 	var wg sync.WaitGroup
 	for range workerCount {
 		wg.Go(func() {
-			runWorker(ctx, jobs, cancel, fn, updated, errCh)
+			runWorker(ctx, jobs, fn, updated, errCh)
 		})
 	}
 
@@ -65,7 +65,7 @@ func queueJobs(ctx context.Context, jobs chan<- attackJob, targets []cameradar.S
 	}
 }
 
-func runWorker(ctx context.Context, jobs <-chan attackJob, cancelFn func(), fn attackFn, updated []cameradar.Stream, errCh chan error) {
+func runWorker(ctx context.Context, jobs <-chan attackJob, fn attackFn, updated []cameradar.Stream, errCh chan error) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -77,13 +77,18 @@ func runWorker(ctx context.Context, jobs <-chan attackJob, cancelFn func(), fn a
 
 			stream, err := fn(ctx, job.stream)
 			if err != nil {
+				// Record the first error but keep processing the remaining
+				// targets. A failure on one camera (e.g. a host that masscan
+				// flagged but is now unreachable) must not drop results for
+				// every other camera in the batch. Cancellation is reserved
+				// for a genuine ctx.Done().
 				select {
 				case errCh <- err:
 				default:
 				}
 
-				cancelFn()
-				return
+				updated[job.index] = stream
+				continue
 			}
 
 			updated[job.index] = stream

--- a/internal/attack/workers.go
+++ b/internal/attack/workers.go
@@ -2,6 +2,8 @@ package attack
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"runtime"
 	"sync"
 
@@ -20,7 +22,7 @@ func runParallel(ctx context.Context, targets []cameradar.Stream, fn attackFn) (
 		return targets, nil
 	}
 
-	errCh := make(chan error, 1)
+	errCh := make(chan error, workerCount)
 	jobs := make(chan attackJob)
 
 	updated := make([]cameradar.Stream, len(targets))
@@ -32,7 +34,7 @@ func runParallel(ctx context.Context, targets []cameradar.Stream, fn attackFn) (
 	var wg sync.WaitGroup
 	for range workerCount {
 		wg.Go(func() {
-			runWorker(ctx, jobs, fn, updated, errCh)
+			errCh <- runWorker(ctx, jobs, fn, updated)
 		})
 	}
 
@@ -40,14 +42,18 @@ func runParallel(ctx context.Context, targets []cameradar.Stream, fn attackFn) (
 	close(jobs)
 
 	wg.Wait()
+	close(errCh)
 
-	select {
-	case err := <-errCh:
-		return updated, err
-	default:
+	// Aggregate every worker's errors instead of surfacing only the first one.
+	// A failure on one camera (e.g. a host that masscan flagged but is now
+	// unreachable) must not drop results for every other camera in the batch,
+	// and all failures are returned together so callers can inspect each.
+	var errs error
+	for err := range errCh {
+		errs = errors.Join(errs, err)
 	}
 
-	return updated, nil
+	return updated, errs
 }
 
 type attackJob struct {
@@ -65,33 +71,26 @@ func queueJobs(ctx context.Context, jobs chan<- attackJob, targets []cameradar.S
 	}
 }
 
-func runWorker(ctx context.Context, jobs <-chan attackJob, fn attackFn, updated []cameradar.Stream, errCh chan error) {
+func runWorker(ctx context.Context, jobs <-chan attackJob, fn attackFn, updated []cameradar.Stream) error {
+	var errs error
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return errs
 		case job, ok := <-jobs:
 			if !ok {
-				return
+				return errs
 			}
 
 			stream, err := fn(ctx, job.stream)
+			updated[job.index] = stream
 			if err != nil {
-				// Record the first error but keep processing the remaining
-				// targets. A failure on one camera (e.g. a host that masscan
-				// flagged but is now unreachable) must not drop results for
+				// Aggregate the error but keep processing the remaining
+				// targets. A failure on one camera must not drop results for
 				// every other camera in the batch. Cancellation is reserved
 				// for a genuine ctx.Done().
-				select {
-				case errCh <- err:
-				default:
-				}
-
-				updated[job.index] = stream
-				continue
+				errs = errors.Join(errs, fmt.Errorf("attacking %s: %w", stream, err))
 			}
-
-			updated[job.index] = stream
 		}
 	}
 }

--- a/internal/ui/plain.go
+++ b/internal/ui/plain.go
@@ -73,7 +73,10 @@ func (r *PlainReporter) Error(step cameradar.Step, err error) {
 func (r *PlainReporter) Summary(streams []cameradar.Stream, err error) {
 	_, _ = fmt.Fprintln(r.out, "Summary")
 	_, _ = fmt.Fprintln(r.out, "-------")
-	_, _ = fmt.Fprintln(r.out, FormatSummary(streams, err))
+	_, _ = fmt.Fprintln(r.out, FormatSummary(streams))
+	if err != nil {
+		r.Error(cameradar.StepSummary, err)
+	}
 }
 
 // Close is a no-op for the plain reporter.

--- a/internal/ui/plain_test.go
+++ b/internal/ui/plain_test.go
@@ -32,6 +32,29 @@ func TestPlainReporter_Outputs(t *testing.T) {
 		assert.Contains(t, content, "Summary\n-------\nAccessible streams: 0")
 	})
 
+	t.Run("surfaces summary error", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		reporter := ui.NewPlainReporter(out, false)
+
+		reporter.Summary([]cameradar.Stream{}, errors.New("boom"))
+
+		content := out.String()
+		assert.Contains(t, content, "Summary\n-------\nAccessible streams: 0")
+		assert.Contains(t, content, " [EROR] ")
+		assert.Contains(t, content, "boom")
+	})
+
+	t.Run("omits error line when summary error is nil", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		reporter := ui.NewPlainReporter(out, false)
+
+		reporter.Summary([]cameradar.Stream{}, nil)
+
+		content := out.String()
+		assert.Contains(t, content, "Accessible streams: 0")
+		assert.NotContains(t, content, " [EROR] ")
+	})
+
 	t.Run("respects debug flag and empty input", func(t *testing.T) {
 		out := &bytes.Buffer{}
 		reporter := ui.NewPlainReporter(out, false)

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -17,6 +17,7 @@ type modelState struct {
 	logs            []logMsg
 	summaryStreams  []cameradar.Stream
 	summaryFinal    bool
+	summaryErr      error
 	buildInfo       BuildInfo
 	cancel          context.CancelFunc
 	debug           bool
@@ -92,6 +93,7 @@ func (m *modelState) handleLogMsg(msg logMsg) {
 func (m *modelState) handleSummaryMsg(msg summaryMsg) {
 	m.summaryStreams = msg.streams
 	m.summaryFinal = msg.final
+	m.summaryErr = msg.err
 	if msg.final {
 		m.status[cameradar.StepSummary] = stateDone
 		markStepComplete(m, cameradar.StepSummary)
@@ -202,6 +204,10 @@ func (m *modelState) FinalView() string {
 	builder.WriteString(sectionStyle.Render(summaryTitle))
 	builder.WriteString("\n")
 	builder.WriteString(renderSummaryTablePlain(columns, rows))
+	if m.summaryErr != nil {
+		builder.WriteString("\n")
+		builder.WriteString(errorStyle.Render("Error: " + m.summaryErr.Error()))
+	}
 	return builder.String()
 }
 

--- a/internal/ui/state_test.go
+++ b/internal/ui/state_test.go
@@ -1,0 +1,41 @@
+package ui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Ullaakut/cameradar/v6"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFinalViewRendersSummaryError(t *testing.T) {
+	t.Run("appends error after summary", func(t *testing.T) {
+		m := &modelState{
+			steps:      cameradar.Steps(),
+			status:     summaryStatusAllDone(),
+			buildInfo:  BuildInfo{Version: "dev", Commit: "none"},
+			summaryErr: errors.New("boom"),
+		}
+
+		view := m.FinalView()
+
+		summaryIdx := strings.Index(view, "Summary - Streams")
+		errIdx := strings.Index(view, "Error: boom")
+		assert.GreaterOrEqual(t, summaryIdx, 0)
+		assert.GreaterOrEqual(t, errIdx, 0)
+		assert.Greater(t, errIdx, summaryIdx)
+	})
+
+	t.Run("omits error line when none set", func(t *testing.T) {
+		m := &modelState{
+			steps:     cameradar.Steps(),
+			status:    summaryStatusAllDone(),
+			buildInfo: BuildInfo{Version: "dev", Commit: "none"},
+		}
+
+		view := m.FinalView()
+
+		assert.NotContains(t, view, "Error:")
+	})
+}

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -11,7 +11,7 @@ import (
 )
 
 // FormatSummary builds a human-readable summary of discovered streams.
-func FormatSummary(streams []cameradar.Stream, _ error) string {
+func FormatSummary(streams []cameradar.Stream) string {
 	accessible, others := partitionStreams(streams)
 
 	var builder strings.Builder

--- a/internal/ui/summary_test.go
+++ b/internal/ui/summary_test.go
@@ -1,7 +1,6 @@
 package ui_test
 
 import (
-	"errors"
 	"net/netip"
 	"strings"
 	"testing"
@@ -26,7 +25,7 @@ func TestFormatSummaryIPv6BracketsHost(t *testing.T) {
 		},
 	}
 
-	got := ui.FormatSummary(streams, nil)
+	got := ui.FormatSummary(streams)
 
 	// IPv6 hosts must be bracketed to form valid URLs.
 	assert.Contains(t, got, "RTSP URL: rtsp://user:pass@[fe80::1]:554/stream")
@@ -37,7 +36,6 @@ func TestFormatSummary(t *testing.T) {
 	tests := []struct {
 		name            string
 		streams         []cameradar.Stream
-		err             error
 		wantContains    []string
 		wantNotContains []string
 		orderedPairs    [][2]string
@@ -55,7 +53,7 @@ func TestFormatSummary(t *testing.T) {
 			},
 		},
 		{
-			name: "mixed streams with error",
+			name: "mixed streams",
 			streams: []cameradar.Stream{
 				{
 					Device:             "Model B",
@@ -83,7 +81,6 @@ func TestFormatSummary(t *testing.T) {
 					AuthenticationType: cameradar.AuthDigest,
 				},
 			},
-			err: errors.New("boom"),
 			wantContains: []string{
 				"Accessible streams: 2",
 				"Other discovered streams: 1",
@@ -134,7 +131,7 @@ func TestFormatSummary(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := ui.FormatSummary(test.streams, test.err)
+			got := ui.FormatSummary(test.streams)
 
 			for _, expected := range test.wantContains {
 				assert.Contains(t, got, expected)

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -56,6 +56,7 @@ type closeMsg struct{}
 type summaryMsg struct {
 	streams []cameradar.Stream
 	final   bool
+	err     error
 }
 
 type summaryTable struct {
@@ -181,10 +182,10 @@ func (r *TUIReporter) Error(step cameradar.Step, err error) {
 }
 
 // Summary implements Reporter.
-func (r *TUIReporter) Summary(streams []cameradar.Stream, _ error) {
+func (r *TUIReporter) Summary(streams []cameradar.Stream, err error) {
 	cloned := copyStreams(streams)
 	r.recordSummary(cloned)
-	r.send(summaryMsg{streams: cloned, final: true})
+	r.send(summaryMsg{streams: cloned, final: true, err: err})
 }
 
 // UpdateSummary updates the summary section with partial results.


### PR DESCRIPTION
Fixes #450

A per-camera failure in a worker called `cancelFn()`, cancelling the context shared by all workers, and `Attack` short-circuited before the validate phase. As a result one dead host (a port masscan flagged but now closed) left every other camera `Available=false`.

Workers now record the first error and keep processing the remaining targets, reserving cancellation for genuine context cancellation. `Attack` runs every phase and surfaces the first error afterwards, so healthy cameras are still validated while non-network failures (404 / no media / setup) keep returning an error, preserving the existing error-path tests.

Added a regression test that places an unreachable host (a deliberately closed port) ahead of a healthy RTSP server and asserts the healthy camera still comes back `Available=true`. The full `./internal/attack/...` suite passes with `-race`.