### PR TITLE
fix(output): strip CR/LF from device label in m3u playlist

### DIFF
--- a/internal/output/m3u.go
+++ b/internal/output/m3u.go
@@ -110,7 +110,8 @@ func formatStreamLabel(stream cameradar.Stream) string {
 	if stream.Device == "" {
 		return label
 	}
-	return label + " (" + stream.Device + ")"
+	device := strings.NewReplacer("\r\n", " ", "\r", " ", "\n", " ").Replace(stream.Device)
+	return label + " (" + device + ")"
 }
 
 func formatRTSPURL(stream cameradar.Stream) string {

--- a/internal/output/m3u_test.go
+++ b/internal/output/m3u_test.go
@@ -41,3 +41,40 @@ func TestBuildM3U_EncodesCredentials(t *testing.T) {
 	assert.Equal(t, "192.0.2.10:554", u.Host)
 	assert.Equal(t, "/stream", u.Path)
 }
+
+func TestBuildM3U_SanitizesDeviceLabelNewlines(t *testing.T) {
+	stream := cameradar.Stream{
+		Address: netip.MustParseAddr("192.0.2.20"),
+		Port:    554,
+		Routes:  []string{"stream"},
+		Device:  "Cam\r\n#EXTINF:-1,Injected\nrtsp://attacker.example/evil\r",
+	}
+
+	playlist := output.BuildM3U([]cameradar.Stream{stream})
+
+	extinfCount := 0
+	for _, line := range strings.Split(playlist, "\n") {
+		if strings.HasPrefix(line, "#EXTINF") {
+			extinfCount++
+		}
+	}
+	assert.Equal(t, 1, extinfCount, "device newlines must not inject extra #EXTINF entries")
+
+	for _, line := range strings.Split(playlist, "\n") {
+		assert.NotEqual(t, "rtsp://attacker.example/evil", strings.TrimSpace(line),
+			"device newlines must not inject a standalone rtsp line")
+	}
+}
+
+func TestBuildM3U_RendersNormalDeviceLabel(t *testing.T) {
+	stream := cameradar.Stream{
+		Address: netip.MustParseAddr("192.0.2.30"),
+		Port:    554,
+		Routes:  []string{"stream"},
+		Device:  "Hikvision DS-2CD",
+	}
+
+	playlist := output.BuildM3U([]cameradar.Stream{stream})
+
+	assert.Contains(t, playlist, "192.0.2.30:554 (Hikvision DS-2CD)")
+}


### PR DESCRIPTION
Fixes #454.

The M3U writer embedded `stream.Device` into the `#EXTINF:-1,<label>` line without sanitizing line breaks. Because `Device` comes from the scanned host's banner (nmap `Service.Product`), a malicious or compromised target can put a newline in its banner and inject arbitrary `#EXTINF` directives and standalone `rtsp://` URL lines into the generated playlist.

This is distinct from #440/#447: the `rtsp://` line is already correctly encoded via `url.URL`, but the label field was not.

### Change

`formatStreamLabel` now strips CR/LF (`\r\n`, `\r`, `\n` -> space) from the device name before composing the label. The non-device path is unchanged.

### Tests

`internal/output/m3u_test.go`:
- `TestBuildM3U_SanitizesDeviceLabelNewlines` builds a playlist from a stream whose `Device` contains `\r` and `\n` and asserts exactly one `#EXTINF` line and no standalone injected `rtsp://attacker` line. Verified it fails on master and passes with the fix.
- `TestBuildM3U_RendersNormalDeviceLabel` confirms a normal device name still renders.

`go test ./internal/output/...` passes.