### PR TITLE
fix(attack): clamp probeDescribeHeaders timeout to default when timeout is zero

### DIFF
--- a/internal/attack/rtsp.go
+++ b/internal/attack/rtsp.go
@@ -98,7 +98,8 @@ func (a Attacker) describeStatus(stream cameradar.Stream) (base.StatusCode, erro
 // NOTE: We do not use gortsplib here because it does not expose response headers when the status code is 401 Unauthorized,
 // which is exactly what we need in order to detect authentication methods.
 func (a Attacker) probeDescribeHeaders(ctx context.Context, u *base.URL) (base.StatusCode, base.Header, error) {
-	dialer := &net.Dialer{Timeout: a.timeout}
+	timeout := frameProbeTimeout(a.timeout)
+	dialer := &net.Dialer{Timeout: timeout}
 
 	var (
 		conn net.Conn
@@ -123,7 +124,7 @@ func (a Attacker) probeDescribeHeaders(ctx context.Context, u *base.URL) (base.S
 
 	deadline, ok := ctx.Deadline()
 	if !ok {
-		deadline = time.Now().Add(a.timeout)
+		deadline = time.Now().Add(timeout)
 	}
 
 	err = conn.SetDeadline(deadline)

--- a/internal/attack/rtsp_timeout_internal_test.go
+++ b/internal/attack/rtsp_timeout_internal_test.go
@@ -1,0 +1,89 @@
+package attack
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bluenviron/gortsplib/v5/pkg/base"
+)
+
+// listenAcceptNoReply starts a loopback TCP server that accepts connections but
+// never sends any reply, so a DESCRIBE probe blocks until its deadline fires.
+func listenAcceptNoReply(t *testing.T) (string, func()) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open without replying.
+			go func(c net.Conn) {
+				<-done
+				_ = c.Close()
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String(), func() {
+		close(done)
+		_ = ln.Close()
+	}
+}
+
+func TestProbeDescribeHeadersTimeoutZeroDoesNotFailInstantly(t *testing.T) {
+	addr, cleanup := listenAcceptNoReply(t)
+	defer cleanup()
+
+	a := Attacker{timeout: 0}
+	u := &base.URL{Scheme: schemeRTSP, Host: addr, Path: "/"}
+
+	start := time.Now()
+	_, _, err := a.probeDescribeHeaders(context.Background(), u)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from the unresponsive server, got nil")
+	}
+
+	// With the fix, timeout==0 is clamped to the default (2s). Before the fix the
+	// deadline was set to time.Now() and the probe failed in ~225µs.
+	if elapsed < time.Second {
+		t.Fatalf("probe with timeout=0 failed too fast (%v); expected to block ~2s on real deadline", elapsed)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("probe with timeout=0 took too long (%v)", elapsed)
+	}
+}
+
+func TestProbeDescribeHeadersTimeoutHonored(t *testing.T) {
+	addr, cleanup := listenAcceptNoReply(t)
+	defer cleanup()
+
+	a := Attacker{timeout: 300 * time.Millisecond}
+	u := &base.URL{Scheme: schemeRTSP, Host: addr, Path: "/"}
+
+	start := time.Now()
+	_, _, err := a.probeDescribeHeaders(context.Background(), u)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from the unresponsive server, got nil")
+	}
+
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("probe failed too fast (%v); expected ~300ms", elapsed)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("probe took too long (%v); expected ~300ms", elapsed)
+	}
+}

--- a/internal/attack/rtsp_timeout_internal_test.go
+++ b/internal/attack/rtsp_timeout_internal_test.go
@@ -7,17 +7,52 @@ import (
 	"time"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+func TestProbeDescribeHeadersTimeoutZeroDoesNotFailInstantly(t *testing.T) {
+	addr := listenAcceptNoReply(t)
+
+	a := Attacker{timeout: 0}
+	u := &base.URL{Scheme: schemeRTSP, Host: addr, Path: "/"}
+
+	start := time.Now()
+	_, _, err := a.probeDescribeHeaders(context.Background(), u)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "expected an error from the unresponsive server")
+
+	// With the fix, timeout==0 is clamped to the default (2s). Before the fix the
+	// deadline was set to time.Now() and the probe failed in ~225µs.
+	assert.Greater(t, elapsed, time.Second, "probe with timeout=0 failed too fast; expected to block ~2s on real deadline")
+	assert.Less(t, elapsed, 5*time.Second, "probe with timeout=0 took too long")
+}
+
+func TestProbeDescribeHeadersTimeoutHonored(t *testing.T) {
+	addr := listenAcceptNoReply(t)
+
+	a := Attacker{timeout: 300 * time.Millisecond}
+	u := &base.URL{Scheme: schemeRTSP, Host: addr, Path: "/"}
+
+	start := time.Now()
+	_, _, err := a.probeDescribeHeaders(context.Background(), u)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "expected an error from the unresponsive server")
+
+	assert.Greater(t, elapsed, 150*time.Millisecond, "probe failed too fast; expected ~300ms")
+	assert.Less(t, elapsed, time.Second, "probe took too long; expected ~300ms")
+}
+
 // listenAcceptNoReply starts a loopback TCP server that accepts connections but
-// never sends any reply, so a DESCRIBE probe blocks until its deadline fires.
-func listenAcceptNoReply(t *testing.T) (string, func()) {
+// never sends any reply, so a DESCRIBE probe blocks until its deadline fires. It
+// returns the server address and registers cleanup via t.Cleanup.
+func listenAcceptNoReply(t *testing.T) string {
 	t.Helper()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
+	require.NoError(t, err, "listen")
 
 	done := make(chan struct{})
 	go func() {
@@ -34,56 +69,10 @@ func listenAcceptNoReply(t *testing.T) (string, func()) {
 		}
 	}()
 
-	return ln.Addr().String(), func() {
+	t.Cleanup(func() {
 		close(done)
 		_ = ln.Close()
-	}
-}
+	})
 
-func TestProbeDescribeHeadersTimeoutZeroDoesNotFailInstantly(t *testing.T) {
-	addr, cleanup := listenAcceptNoReply(t)
-	defer cleanup()
-
-	a := Attacker{timeout: 0}
-	u := &base.URL{Scheme: schemeRTSP, Host: addr, Path: "/"}
-
-	start := time.Now()
-	_, _, err := a.probeDescribeHeaders(context.Background(), u)
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("expected an error from the unresponsive server, got nil")
-	}
-
-	// With the fix, timeout==0 is clamped to the default (2s). Before the fix the
-	// deadline was set to time.Now() and the probe failed in ~225µs.
-	if elapsed < time.Second {
-		t.Fatalf("probe with timeout=0 failed too fast (%v); expected to block ~2s on real deadline", elapsed)
-	}
-	if elapsed > 5*time.Second {
-		t.Fatalf("probe with timeout=0 took too long (%v)", elapsed)
-	}
-}
-
-func TestProbeDescribeHeadersTimeoutHonored(t *testing.T) {
-	addr, cleanup := listenAcceptNoReply(t)
-	defer cleanup()
-
-	a := Attacker{timeout: 300 * time.Millisecond}
-	u := &base.URL{Scheme: schemeRTSP, Host: addr, Path: "/"}
-
-	start := time.Now()
-	_, _, err := a.probeDescribeHeaders(context.Background(), u)
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("expected an error from the unresponsive server, got nil")
-	}
-
-	if elapsed < 150*time.Millisecond {
-		t.Fatalf("probe failed too fast (%v); expected ~300ms", elapsed)
-	}
-	if elapsed > time.Second {
-		t.Fatalf("probe took too long (%v); expected ~300ms", elapsed)
-	}
+	return ln.Addr().String()
 }


### PR DESCRIPTION
Fixes #456.

## Problem

`probeDescribeHeaders` (`internal/attack/rtsp.go`) used `a.timeout` directly for the dialer and the connection deadline. With `--timeout 0` (a reachable, unvalidated config value) and a context without a deadline (production uses `signal.NotifyContext`), the fallback deadline became `time.Now().Add(0)` — an already-elapsed deadline — so every auth-detection probe failed instantly (~225µs).

This is an internal inconsistency: `newRTSPClient` lets gortsplib apply its ~10s default for `timeout == 0`, and the frame-probe path already maps `<= 0` to a 2s default via the `frameProbeTimeout` helper. Only `probeDescribeHeaders` lacked this clamping, so auth detection silently broke with `--timeout 0` while the rest of the pipeline kept working.

## Fix

Reuse the existing `frameProbeTimeout` helper (same `attack` package) for both the dialer timeout and the fallback deadline. The `ctx.Deadline()` branch is preserved, so a real context deadline still takes precedence.

## Verification

Added an internal test using a loopback TCP server that accepts but never replies:
- `timeout == 0` now blocks ~2s (the clamped default) and fails on a real deadline, instead of ~225µs.
- `timeout == 300ms` fails at ~300ms.

Confirmed the `timeout == 0` test fails on the current code (228µs) and passes with the fix. `go build ./...` and the `internal/attack` package tests pass.