### PR TITLE
fix: reject control characters in dictionary credentials

### DIFF
--- a/internal/dict/loader.go
+++ b/internal/dict/loader.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 )
 
@@ -122,15 +123,8 @@ func parseCredentials(content []byte) (credentials, error) {
 		return strings.ContainsFunc(s, func(r rune) bool { return r < 0x20 || r == 0x7f })
 	}
 
-	for _, username := range creds.Usernames {
-		if hasControlChar(username) {
-			return credentials{}, fmt.Errorf("invalid credential: control characters are not allowed")
-		}
-	}
-	for _, password := range creds.Passwords {
-		if hasControlChar(password) {
-			return credentials{}, fmt.Errorf("invalid credential: control characters are not allowed")
-		}
+	if slices.ContainsFunc(creds.Usernames, hasControlChar) || slices.ContainsFunc(creds.Passwords, hasControlChar) {
+		return credentials{}, errors.New("invalid credential: control characters are not allowed")
 	}
 
 	return creds, nil

--- a/internal/dict/loader.go
+++ b/internal/dict/loader.go
@@ -118,6 +118,21 @@ func parseCredentials(content []byte) (credentials, error) {
 		return credentials{}, fmt.Errorf("reading dictionary contents: %w", err)
 	}
 
+	hasControlChar := func(s string) bool {
+		return strings.ContainsFunc(s, func(r rune) bool { return r < 0x20 || r == 0x7f })
+	}
+
+	for _, username := range creds.Usernames {
+		if hasControlChar(username) {
+			return credentials{}, fmt.Errorf("invalid credential: control characters are not allowed")
+		}
+	}
+	for _, password := range creds.Passwords {
+		if hasControlChar(password) {
+			return credentials{}, fmt.Errorf("invalid credential: control characters are not allowed")
+		}
+	}
+
 	return creds, nil
 }
 

--- a/internal/dict/loader_test.go
+++ b/internal/dict/loader_test.go
@@ -198,6 +198,47 @@ func TestNew_RoutesSanitization(t *testing.T) {
 	}
 }
 
+func TestNew_CredentialsSanitization(t *testing.T) {
+	tempDir := t.TempDir()
+	routesPath := writeTempFile(t, tempDir, "routes", "stream\n")
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{
+			name:    "valid credentials parse successfully",
+			content: `{"usernames":["alice"],"passwords":["secret"]}`,
+			wantErr: false,
+		},
+		{
+			name:    "rejects CRLF in username",
+			content: `{"usernames":["admin\r\nInjected: header"],"passwords":["secret"]}`,
+			wantErr: true,
+		},
+		{
+			name:    "rejects control character in password",
+			content: `{"usernames":["alice"],"passwords":["sec\u0001ret"]}`,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			credsPath := writeTempFile(t, tempDir, "creds-"+test.name+".json", test.content)
+
+			_, err := dict.New(credsPath, routesPath)
+			if test.wantErr {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, "control characters are not allowed")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func writeTempFile(t *testing.T, dir, name, content string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)

--- a/internal/dict/loader_test.go
+++ b/internal/dict/loader_test.go
@@ -203,24 +203,27 @@ func TestNew_CredentialsSanitization(t *testing.T) {
 	routesPath := writeTempFile(t, tempDir, "routes", "stream\n")
 
 	tests := []struct {
-		name    string
-		content string
-		wantErr bool
+		name            string
+		content         string
+		wantErr         require.ErrorAssertionFunc
+		wantErrContains string
 	}{
 		{
 			name:    "valid credentials parse successfully",
 			content: `{"usernames":["alice"],"passwords":["secret"]}`,
-			wantErr: false,
+			wantErr: require.NoError,
 		},
 		{
-			name:    "rejects CRLF in username",
-			content: `{"usernames":["admin\r\nInjected: header"],"passwords":["secret"]}`,
-			wantErr: true,
+			name:            "rejects CRLF in username",
+			content:         `{"usernames":["admin\r\nInjected: header"],"passwords":["secret"]}`,
+			wantErr:         require.Error,
+			wantErrContains: "control characters are not allowed",
 		},
 		{
-			name:    "rejects control character in password",
-			content: `{"usernames":["alice"],"passwords":["sec\u0001ret"]}`,
-			wantErr: true,
+			name:            "rejects control character in password",
+			content:         `{"usernames":["alice"],"passwords":["sec\u0001ret"]}`,
+			wantErr:         require.Error,
+			wantErrContains: "control characters are not allowed",
 		},
 	}
 
@@ -229,12 +232,10 @@ func TestNew_CredentialsSanitization(t *testing.T) {
 			credsPath := writeTempFile(t, tempDir, "creds-"+test.name+".json", test.content)
 
 			_, err := dict.New(credsPath, routesPath)
-			if test.wantErr {
-				require.Error(t, err)
-				assert.ErrorContains(t, err, "control characters are not allowed")
-				return
+			test.wantErr(t, err)
+			if test.wantErrContains != "" {
+				assert.ErrorContains(t, err, test.wantErrContains)
 			}
-			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Credentials loaded from the dictionary were not validated. A username or password containing control characters (e.g. CR/LF) could end up in the RTSP request sent to scanned hosts. This rejects credential entries containing ASCII control characters at load time, matching the route sanitization added in #449.