### PR TITLE
fix(stream): preserve query-string routes instead of percent-encoding ?

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -87,12 +87,19 @@ func (s Stream) String() string {
 	scheme := s.resolvedScheme()
 
 	host := net.JoinHostPort(s.Address.String(), strconv.Itoa(int(s.Port)))
-	path := "/" + strings.TrimLeft(strings.TrimSpace(s.Route()), "/")
+	route := strings.TrimLeft(strings.TrimSpace(s.Route()), "/")
+	pathPart := "/" + route
+	rawQuery := ""
+	if i := strings.IndexByte(route, '?'); i >= 0 {
+		pathPart = "/" + route[:i]
+		rawQuery = route[i+1:]
+	}
 
 	u := &url.URL{
-		Scheme: scheme,
-		Host:   host,
-		Path:   path,
+		Scheme:   scheme,
+		Host:     host,
+		Path:     pathPart,
+		RawQuery: rawQuery,
 	}
 	if s.Username != "" || s.Password != "" {
 		u.User = url.UserPassword(s.Username, s.Password)

--- a/stream_scheme_test.go
+++ b/stream_scheme_test.go
@@ -1,11 +1,48 @@
 package cameradar_test
 
 import (
+	"net/netip"
+	"strings"
 	"testing"
 
 	"github.com/Ullaakut/cameradar/v6"
 	"github.com/stretchr/testify/require"
 )
+
+func TestStreamString_QueryRoute(t *testing.T) {
+	addr := netip.MustParseAddr("192.168.1.1")
+	tests := []struct {
+		name      string
+		route     string
+		wantURL   string
+		wantQuery string
+	}{
+		{
+			name:      "route with query string",
+			route:     "cam/realmonitor?channel=0&subtype=0",
+			wantURL:   "rtsp://192.168.1.1:554/cam/realmonitor?channel=0&subtype=0",
+			wantQuery: "channel=0&subtype=0",
+		},
+		{
+			name:    "plain route unchanged",
+			route:   "live/ch0",
+			wantURL: "rtsp://192.168.1.1:554/live/ch0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := cameradar.Stream{
+				Address: addr,
+				Port:    554,
+				Routes:  []string{test.route},
+			}
+			got := s.String()
+			require.Equal(t, test.wantURL, got)
+			require.False(t, strings.Contains(got, "%3F"), "URL must not percent-encode '?': %s", got)
+		})
+	}
+}
 
 func TestStreamRTSPScheme(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
`Stream.String()` puts the whole route in `url.URL.Path`, so a route with a query string like `cam/realmonitor?channel=0&subtype=0` gets the `?` percent-encoded to `%3F` and the DESCRIBE request sends a literal `%3F`. Cameras that key streams off query params (Dahua, Axis, etc.) return 404, so those routes are never discovered. 17 of the default routes contain `?`.

Fix: split the route on `?` and use `RawQuery` so the query separator is preserved. Added a test.