### PR TITLE
fix(skip): avoid uint16 overflow infinite loop for port ranges ending at 65535

### DIFF
--- a/internal/scan/skip/skip.go
+++ b/internal/scan/skip/skip.go
@@ -112,9 +112,9 @@ func parsePortValue(ctx context.Context, value string) ([]uint16, error) {
 			return nil, fmt.Errorf("invalid port range %q", value)
 		}
 
-		ports := make([]uint16, 0, end-start+1)
-		for port := start; port <= end; port++ {
-			ports = append(ports, port)
+		ports := make([]uint16, 0, int(end)-int(start)+1)
+		for p := int(start); p <= int(end); p++ {
+			ports = append(ports, uint16(p)) // #nosec G115 -- p is bounded to [1, 65535] by parsePortNumber
 		}
 		return ports, nil
 	}

--- a/internal/scan/skip/skip_test.go
+++ b/internal/scan/skip/skip_test.go
@@ -56,6 +56,20 @@ func TestNew_ExpandsTargetsAndPorts(t *testing.T) {
 	assert.ElementsMatch(t, want, got)
 }
 
+func TestNew_ExpandsPortRangeEndingAt65535(t *testing.T) {
+	scanner := skip.New([]string{"192.0.2.1"}, []string{"65534-65535"})
+
+	streams, err := scanner.Scan(t.Context())
+	require.NoError(t, err)
+	require.Len(t, streams, 2)
+
+	var got []uint16
+	for _, stream := range streams {
+		got = append(got, stream.Port)
+	}
+	assert.ElementsMatch(t, []uint16{65534, 65535}, got)
+}
+
 func TestNew_ReturnsErrorOnInvalidPortRange(t *testing.T) {
 	scanner := skip.New([]string{"192.0.2.1"}, []string{"8555-8554"})
 


### PR DESCRIPTION
When expanding a port range whose end is 65535, the loop variable was `uint16`. After processing port 65535, `port++` wraps to 0, and since `0 <= 65535` the loop never terminates -- causing a CPU spin and unbounded memory growth.

Fix: iterate with an `int` variable and convert to `uint16` only on append. The capacity expression also uses `int` arithmetic to avoid the same wrap at the `make` call.

A test for `"65534-65535"` is added to `skip_test.go`; the test terminating proves the fix.