### PR TITLE
fix(attack): bound DESCRIBE response read and keep headers on EOF

### DIFF
--- a/internal/attack/rtsp.go
+++ b/internal/attack/rtsp.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/textproto"
 	"strconv"
@@ -24,6 +25,10 @@ const (
 	schemeRTSPS = "rtsps"
 	schemeHTTP  = "http"
 	schemeHTTPS = "https"
+
+	// maxResponseBytes caps the DESCRIBE response size to guard against memory
+	// exhaustion from a malicious or misbehaving peer.
+	maxResponseBytes = 64 * 1024
 )
 
 func (a Attacker) newRTSPClient(stream cameradar.Stream) (*gortsplib.Client, error) {
@@ -142,7 +147,7 @@ func (a Attacker) probeDescribeHeaders(ctx context.Context, u *base.URL) (base.S
 		return 0, nil, err
 	}
 
-	reader := textproto.NewReader(bufio.NewReader(conn))
+	reader := textproto.NewReader(bufio.NewReader(io.LimitReader(conn, maxResponseBytes)))
 	statusLine, err := reader.ReadLine()
 	if err != nil {
 		return 0, nil, err
@@ -158,7 +163,7 @@ func (a Attacker) probeDescribeHeaders(ctx context.Context, u *base.URL) (base.S
 	}
 
 	mimeHeader, err := reader.ReadMIMEHeader()
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return 0, nil, err
 	}
 

--- a/internal/attack/rtsp_probe_internal_test.go
+++ b/internal/attack/rtsp_probe_internal_test.go
@@ -1,0 +1,71 @@
+package attack
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bluenviron/gortsplib/v5/pkg/base"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProbeDescribeHeaders_EOFWithoutBlankLine tests that a peer closing the
+// TCP connection right after the last header (without a trailing blank CRLF
+// line, which is common for non-conforming RTSP cameras) does not cause
+// probeDescribeHeaders to discard the already-parsed status code and headers.
+func TestProbeDescribeHeaders_EOFWithoutBlankLine(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		close(done)
+		_ = ln.Close()
+	})
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		_ = conn.SetDeadline(time.Now().Add(2 * time.Second))
+
+		// Drain the incoming DESCRIBE request.
+		buf := make([]byte, 4096)
+		for {
+			n, err := conn.Read(buf)
+			if err != nil || n == 0 {
+				break
+			}
+			// Stop reading once we see the end of the RTSP request.
+			data := string(buf[:n])
+			if len(data) >= 4 && data[len(data)-4:] == "\r\n\r\n" {
+				break
+			}
+		}
+
+		// Send a 401 response with WWW-Authenticate, then close WITHOUT a
+		// trailing blank CRLF line, simulating a non-conforming RTSP camera.
+		resp := "RTSP/1.0 401 Unauthorized\r\nWWW-Authenticate: Digest realm=\"cam\", nonce=\"x\"\r\n"
+		_, _ = fmt.Fprint(conn, resp)
+		// Close immediately; no trailing \r\n.
+	}()
+
+	addr := ln.Addr().String()
+	a := Attacker{timeout: time.Second}
+	u := &base.URL{Scheme: schemeRTSP, Host: addr, Path: "/"}
+
+	statusCode, headers, err := a.probeDescribeHeaders(context.Background(), u)
+
+	require.NoError(t, err, "EOF without trailing blank line must not be returned as an error")
+	assert.Equal(t, base.StatusCode(401), statusCode, "status code must be 401")
+	require.NotNil(t, headers, "headers must not be nil")
+
+	wwwAuth := headerValues(headers, "WWW-Authenticate")
+	assert.NotEmpty(t, wwwAuth, "WWW-Authenticate header must be present")
+}


### PR DESCRIPTION
The `probeDescribeHeaders` function had two issues:

- **Unbounded response read**: the connection was passed directly to `textproto.NewReader` without a size limit, so a malicious or misbehaving peer could send an arbitrarily large response and exhaust memory. Fixed by wrapping the connection in `io.LimitReader(conn, 64 KiB)`.

- **Lost headers on EOF**: `net/textproto.ReadMIMEHeader` returns already-parsed headers *alongside* `io.EOF` when the peer closes the connection without a terminating blank CRLF line. This is common for non-conforming RTSP cameras. The previous `if err != nil { return ... err }` discarded those headers, causing auth type detection to fall back to Unknown and preventing Digest/Basic credential attacks. Fixed by treating `io.EOF` as non-fatal at that call site.

A focused regression test (`TestProbeDescribeHeaders_EOFWithoutBlankLine`) covers the EOF case using an in-process TCP server that omits the trailing blank line.