### PR TITLE
fix(m3u): emit all discovered routes and strip tabs from device label

### DIFF
--- a/internal/output/m3u.go
+++ b/internal/output/m3u.go
@@ -90,15 +90,33 @@ func BuildM3U(streams []cameradar.Stream) string {
 	var builder strings.Builder
 	builder.WriteString("#EXTM3U\n")
 	for _, stream := range streams {
-		url := stream.String()
-		if url == "" {
+		routes := stream.Routes
+		if len(routes) == 0 {
+			// No routes recorded; let String() append "/" as the default path.
+			url := stream.String()
+			if url == "" {
+				continue
+			}
+			builder.WriteString("#EXTINF:-1,")
+			builder.WriteString(formatStreamLabel(stream))
+			builder.WriteString("\n")
+			builder.WriteString(url)
+			builder.WriteString("\n")
 			continue
 		}
-		builder.WriteString("#EXTINF:-1,")
-		builder.WriteString(formatStreamLabel(stream))
-		builder.WriteString("\n")
-		builder.WriteString(url)
-		builder.WriteString("\n")
+		for _, route := range routes {
+			entry := stream
+			entry.Routes = []string{route}
+			url := entry.String()
+			if url == "" {
+				continue
+			}
+			builder.WriteString("#EXTINF:-1,")
+			builder.WriteString(formatStreamLabel(stream))
+			builder.WriteString("\n")
+			builder.WriteString(url)
+			builder.WriteString("\n")
+		}
 	}
 	return builder.String()
 }
@@ -108,6 +126,6 @@ func formatStreamLabel(stream cameradar.Stream) string {
 	if stream.Device == "" {
 		return label
 	}
-	device := strings.NewReplacer("\r\n", " ", "\r", " ", "\n", " ").Replace(stream.Device)
+	device := strings.NewReplacer("\r\n", " ", "\r", " ", "\n", " ", "\t", " ").Replace(stream.Device)
 	return label + " (" + device + ")"
 }

--- a/internal/output/m3u_test.go
+++ b/internal/output/m3u_test.go
@@ -78,3 +78,37 @@ func TestBuildM3U_RendersNormalDeviceLabel(t *testing.T) {
 
 	assert.Contains(t, playlist, "192.0.2.30:554 (Hikvision DS-2CD)")
 }
+
+func TestBuildM3U_EmitsOneEntryPerRoute(t *testing.T) {
+	stream := cameradar.Stream{
+		Address: netip.MustParseAddr("192.0.2.40"),
+		Port:    554,
+		Routes:  []string{"live/ch0", "live/ch1"},
+	}
+
+	playlist := output.BuildM3U([]cameradar.Stream{stream})
+
+	assert.Contains(t, playlist, "rtsp://192.0.2.40:554/live/ch0")
+	assert.Contains(t, playlist, "rtsp://192.0.2.40:554/live/ch1")
+
+	extinfCount := 0
+	for _, line := range strings.Split(playlist, "\n") {
+		if strings.HasPrefix(line, "#EXTINF") {
+			extinfCount++
+		}
+	}
+	assert.Equal(t, 2, extinfCount, "one #EXTINF entry per route")
+}
+
+func TestBuildM3U_SanitizesDeviceLabelTab(t *testing.T) {
+	stream := cameradar.Stream{
+		Address: netip.MustParseAddr("192.0.2.50"),
+		Port:    554,
+		Routes:  []string{"stream"},
+		Device:  "Cam\tModel",
+	}
+
+	playlist := output.BuildM3U([]cameradar.Stream{stream})
+
+	assert.Contains(t, playlist, "192.0.2.50:554 (Cam Model)")
+}


### PR DESCRIPTION
## What

- `BuildM3U` called `stream.String()` once per stream, which resolves
  only `Routes[0]`. Cameras with multiple discovered routes lost all but
  the first entry in the playlist. The fix loops over `stream.Routes`
  and emits one `#EXTINF + URL` pair per route, falling back to the
  existing single-entry path when `Routes` is empty.

- `formatStreamLabel` already replaced CR, LF, and CRLF with spaces to
  prevent header injection but missed horizontal tab. Added it to
  the replacer alongside the existing control-character pairs (same
  pattern as #455).

## Tests added

- `TestBuildM3U_EmitsOneEntryPerRoute`: stream with two routes yields
  two playlist entries, each with the correct URL.
- `TestBuildM3U_SanitizesDeviceLabelTab`: device string containing a tab
  has the tab replaced with a space in the label.