### PR TITLE
fix(nmap): honor tunnel=ssl scheme and log MAC addresses via debug

### DIFF
--- a/internal/scan/nmap/scanner.go
+++ b/internal/scan/nmap/scanner.go
@@ -74,13 +74,19 @@ func runScan(ctx context.Context, nmap Runner, reporter Reporter) ([]cameradar.S
 			}
 
 			for _, address := range host.Addresses {
-				addr, err := netip.ParseAddr(address.Addr)
-				if err != nil {
-					reporter.Progress(cameradar.StepScan, fmt.Sprintf("Skipping invalid address %q: %v", address.Addr, err))
+				addrType := strings.ToLower(strings.TrimSpace(address.AddrType))
+				if addrType != "" && addrType != "ipv4" && addrType != "ipv6" {
 					continue
 				}
 
-				scheme := ports.InferTunnelScheme(port.ID, port.Service.Name)
+				addr, err := netip.ParseAddr(address.Addr)
+				if err != nil {
+					reporter.Debug(cameradar.StepScan, fmt.Sprintf("Skipping invalid address %q: %v", address.Addr, err))
+					continue
+				}
+
+				scheme := resolveScheme(port.ID, port.Service.Name, port.Service.Tunnel)
+
 				streams = append(streams, cameradar.Stream{
 					Device:  port.Service.Product,
 					Address: addr,
@@ -107,6 +113,23 @@ func updateSummary(reporter Reporter, streams []cameradar.Stream) {
 		return
 	}
 	updater.UpdateSummary(streams)
+}
+
+// resolveScheme returns the tunnel scheme for a port, upgrading to the TLS
+// variant when nmap reports tunnel="ssl".
+func resolveScheme(port uint16, serviceName, tunnel string) string {
+	scheme := ports.InferTunnelScheme(port, serviceName)
+	if !strings.EqualFold(strings.TrimSpace(tunnel), "ssl") {
+		return scheme
+	}
+	switch scheme {
+	case "", "rtsp":
+		return "rtsps"
+	case "http":
+		return "https"
+	default:
+		return scheme
+	}
 }
 
 // Extracting the classifying logic to an external function to avoid nesting if loops.

--- a/internal/scan/nmap/scanner_test.go
+++ b/internal/scan/nmap/scanner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/netip"
+	"strings"
 	"sync"
 	"testing"
 
@@ -17,20 +18,20 @@ func TestScanner_Scan(t *testing.T) {
 	ctx := context.WithValue(t.Context(), contextKey("trace"), "scan")
 
 	tests := []struct {
-		name            string
-		result          *nmaplib.Run
-		err             error
-		wantStreams     []cameradar.Stream
-		wantDebug       []string
-		wantProgress    string
-		wantErrContains string
+		name                string
+		result              *nmaplib.Run
+		err                 error
+		wantStreams          []cameradar.Stream
+		wantDebug            []string
+		wantProgress         string
+		wantNoProgressPrefix string
+		wantErrContains      string
 	}{
 		{
 			name: "filters non-rtsp and closed ports",
 			result: buildRun(nmaplib.Host{
 				Addresses: []nmaplib.Address{
 					{Addr: "127.0.0.1"},
-					{Addr: "not-an-ip"},
 				},
 				Ports: []nmaplib.Port{
 					openPort(8554, "rtsp", "ACME"),
@@ -58,7 +59,6 @@ func TestScanner_Scan(t *testing.T) {
 			result: buildRun(nmaplib.Host{
 				Addresses: []nmaplib.Address{
 					{Addr: "127.0.0.1"},
-					{Addr: "not-an-ip"},
 				},
 				Ports: []nmaplib.Port{
 					openPort(8554, "rtsp", "ACME"),
@@ -148,6 +148,52 @@ func TestScanner_Scan(t *testing.T) {
 			err:             errors.New("scan failed"),
 			wantErrContains: "scanning network",
 		},
+		{
+			name: "upgrades scheme to rtsps when tunnel=ssl",
+			result: buildRun(nmaplib.Host{
+				Addresses: []nmaplib.Address{{Addr: "10.0.0.1"}},
+				Ports: []nmaplib.Port{
+					openPortWithTunnel(8554, "rtsp", "ssl", "CAM"),
+					openPortWithTunnel(8080, "http", "ssl", "CAM"),
+				},
+			}),
+			wantStreams: []cameradar.Stream{
+				{
+					Device:  "CAM",
+					Address: netip.MustParseAddr("10.0.0.1"),
+					Port:    8554,
+					Scheme:  "rtsps",
+				},
+				{
+					Device:  "CAM",
+					Address: netip.MustParseAddr("10.0.0.1"),
+					Port:    8080,
+					Scheme:  "https",
+				},
+			},
+			wantProgress: "Found 2 RTSP streams",
+		},
+		{
+			name: "skips MAC address without progress message",
+			result: buildRun(nmaplib.Host{
+				Addresses: []nmaplib.Address{
+					{Addr: "10.0.0.2", AddrType: "ipv4"},
+					{Addr: "aa:bb:cc:dd:ee:ff", AddrType: "mac"},
+				},
+				Ports: []nmaplib.Port{
+					openPort(554, "rtsp", "CAM"),
+				},
+			}),
+			wantStreams: []cameradar.Stream{
+				{
+					Device:  "CAM",
+					Address: netip.MustParseAddr("10.0.0.2"),
+					Port:    554,
+				},
+			},
+			wantProgress:         "Found 1 RTSP streams",
+			wantNoProgressPrefix: "Skipping",
+		},
 	}
 
 	for _, test := range tests {
@@ -174,6 +220,12 @@ func TestScanner_Scan(t *testing.T) {
 			assert.Equal(t, test.wantStreams, streams)
 			assert.Equal(t, test.wantDebug, reporter.debug)
 			assert.Contains(t, reporter.progress, test.wantProgress)
+			if test.wantNoProgressPrefix != "" {
+				for _, msg := range reporter.progress {
+					assert.False(t, strings.HasPrefix(msg, test.wantNoProgressPrefix),
+						"unexpected progress message: %q", msg)
+				}
+			}
 		})
 	}
 }
@@ -229,6 +281,20 @@ func openPort(id uint16, serviceName, product string) nmaplib.Port {
 		},
 		Service: nmaplib.Service{
 			Name:    serviceName,
+			Product: product,
+		},
+	}
+}
+
+func openPortWithTunnel(id uint16, serviceName, tunnel, product string) nmaplib.Port {
+	return nmaplib.Port{
+		ID: id,
+		State: nmaplib.State{
+			State: string(nmaplib.Open),
+		},
+		Service: nmaplib.Service{
+			Name:    serviceName,
+			Tunnel:  tunnel,
 			Product: product,
 		},
 	}


### PR DESCRIPTION
Two bugs in `internal/scan/nmap/scanner.go`:

**Tunnel=ssl ignored (scheme downgrade):** nmap reports SSL-wrapped services with `service.tunnel="ssl"`. The scanner called `ports.InferTunnelScheme` using only `port.ID` and `service.Name`, ignoring `service.Tunnel`. For an RTSP service on a non-standard port this produces scheme `""`, so the stream is probed without TLS and fails. Fix: add `resolveScheme` helper that upgrades `""`/`"rtsp"` to `"rtsps"` and `"http"` to `"https"` when tunnel is `"ssl"`.

**MAC address spams Progress:** nmap emits `addrtype="mac"` entries for ARP-discovered local hosts. The scanner passed every address to `netip.ParseAddr` without checking `AddrType`, causing a `reporter.Progress("Skipping invalid address ...")` message for every local host. Fix: skip entries whose `AddrType` is neither `""`, `"ipv4"`, nor `"ipv6"`. Genuine parse failures now use `reporter.Debug` instead of `reporter.Progress`.

Tests added for both cases in `scanner_test.go`.