### PR TITLE
fix(ui): strip control chars from device label in terminal summary

### DIFF
--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -62,6 +62,17 @@ func partitionStreams(streams []cameradar.Stream) ([]cameradar.Stream, []camerad
 	return accessible, others
 }
 
+// sanitizeDevice removes ASCII control characters (bytes < 0x20 and 0x7F)
+// from a device banner string to prevent terminal escape sequence injection.
+func sanitizeDevice(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7F {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 func formatStream(stream cameradar.Stream) string {
 	var builder strings.Builder
 	builder.WriteString("• ")
@@ -71,7 +82,7 @@ func formatStream(stream cameradar.Stream) string {
 
 	if stream.Device != "" {
 		builder.WriteString(" (")
-		builder.WriteString(stream.Device)
+		builder.WriteString(sanitizeDevice(stream.Device))
 		builder.WriteString(")")
 	}
 	builder.WriteString("\n")

--- a/internal/ui/summary_test.go
+++ b/internal/ui/summary_test.go
@@ -107,6 +107,25 @@ func TestFormatSummary(t *testing.T) {
 			},
 		},
 		{
+			name: "control characters in device label are stripped",
+			streams: []cameradar.Stream{
+				{
+					Device:             "ACME\x1b\x0d Cam",
+					Address:            netip.MustParseAddr("10.0.0.5"),
+					Port:               554,
+					Available:          true,
+					AuthenticationType: cameradar.AuthNone,
+				},
+			},
+			wantContains: []string{
+				"• 10.0.0.5:554 (ACME Cam)",
+			},
+			wantNotContains: []string{
+				"\x1b",
+				"\x0d",
+			},
+		},
+		{
 			name: "empty discovered credentials render as none",
 			streams: []cameradar.Stream{
 				{


### PR DESCRIPTION
The `Device` field in `formatStream` is written directly to the terminal summary output without sanitizing its contents. This field comes from the nmap service banner, which is attacker-controlled. A device whose banner contains ASCII control characters or ANSI escape sequences could manipulate the user's terminal when the summary is printed.

This is the terminal-summary analogue of #455, which stripped CR/LF from the device label in m3u output.

**Fix:** add a `sanitizeDevice` helper in `summary.go` that strips bytes below 0x20 and 0x7F (DEL) using `strings.Map`, and call it where `stream.Device` is written. A test case is added to `TestFormatSummary` asserting that control characters in the device label do not appear in the output.