### PR TITLE
fix(app): pass scan error to reporter Summary on scan failure

### DIFF
--- a/cameradar.go
+++ b/cameradar.go
@@ -61,7 +61,7 @@ func (a *App) Run(ctx context.Context) error {
 	if err != nil {
 		wrapped := fmt.Errorf("discovering devices: %w", err)
 		a.reporter.Error(StepScan, wrapped)
-		a.reporter.Summary(streams, nil)
+		a.reporter.Summary(streams, wrapped)
 		return wrapped
 	}
 	a.reporter.Done(StepScan, "Scan complete")

--- a/cameradar_test.go
+++ b/cameradar_test.go
@@ -92,7 +92,7 @@ func TestApp_Run(t *testing.T) {
 			wantErrContains: "discovering devices",
 			wantErrorCalls:  1,
 			wantSummary:     streams,
-			wantSummaryErr:  "",
+			wantSummaryErr:  "discovering devices",
 		},
 		{
 			name: "attack error",


### PR DESCRIPTION
When `streamScanner.Scan` fails, `App.Run` calls `reporter.Summary(streams, nil)` — passing `nil` for the error — so the reporter always sees a successful summary even when scanning failed. The attack-error path correctly passes `wrapped` to `Summary`; the scan-error path did not.

Fix: pass `wrapped` instead of `nil` to `reporter.Summary` in the scan-error branch, and update the test expectation accordingly.