### PR TITLE
fix(attack): surface error when context is cancelled before all targets are queued

### DIFF
--- a/internal/attack/workers.go
+++ b/internal/attack/workers.go
@@ -38,7 +38,7 @@ func runParallel(ctx context.Context, targets []cameradar.Stream, fn attackFn) (
 		})
 	}
 
-	queueJobs(ctx, jobs, targets)
+	queued := queueJobs(ctx, jobs, targets)
 	close(jobs)
 
 	wg.Wait()
@@ -53,6 +53,13 @@ func runParallel(ctx context.Context, targets []cameradar.Stream, fn attackFn) (
 		errs = errors.Join(errs, err)
 	}
 
+	// When the context is cancelled before all jobs are queued, the unqueued
+	// targets never run and their slots in updated hold stale pre-attack data.
+	// Surface the cancellation so callers know the results are incomplete.
+	if queued < len(targets) {
+		errs = errors.Join(errs, fmt.Errorf("attack cancelled after %d/%d targets: %w", queued, len(targets), ctx.Err()))
+	}
+
 	return updated, errs
 }
 
@@ -61,14 +68,15 @@ type attackJob struct {
 	stream cameradar.Stream
 }
 
-func queueJobs(ctx context.Context, jobs chan<- attackJob, targets []cameradar.Stream) {
+func queueJobs(ctx context.Context, jobs chan<- attackJob, targets []cameradar.Stream) int {
 	for i, stream := range targets {
 		select {
 		case <-ctx.Done():
-			return
+			return i
 		case jobs <- attackJob{index: i, stream: stream}:
 		}
 	}
+	return len(targets)
 }
 
 func runWorker(ctx context.Context, jobs <-chan attackJob, fn attackFn, updated []cameradar.Stream) error {

--- a/internal/attack/workers_test.go
+++ b/internal/attack/workers_test.go
@@ -1,0 +1,49 @@
+package attack
+
+import (
+	"context"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Ullaakut/cameradar/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunParallel_CancelledContextSurfacesError verifies that when the caller's
+// context is cancelled before all targets have been queued, runParallel returns
+// a non-nil error rather than silently returning incomplete (stale pre-attack)
+// results.  Pre-fix the function returned nil error even though some targets
+// were never processed.
+func TestRunParallel_CancelledContextSurfacesError(t *testing.T) {
+	const total = 10
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	var processed atomic.Int32
+	fn := func(fnCtx context.Context, s cameradar.Stream) (cameradar.Stream, error) {
+		// Cancel after the first job starts so that subsequent targets are
+		// never queued.  The fn itself still succeeds for this one job.
+		if processed.Add(1) == 1 {
+			cancel()
+		}
+		s.RouteFound = true
+		return s, nil
+	}
+
+	targets := make([]cameradar.Stream, total)
+	for i := range targets {
+		targets[i] = cameradar.Stream{
+			Address: netip.MustParseAddr("127.0.0.1"),
+			Port:    uint16(8554 + i),
+		}
+	}
+
+	_, err := runParallel(ctx, targets, fn)
+
+	// Pre-fix: err == nil even though only 1 of 10 targets was processed.
+	// Post-fix: err wraps context.Canceled and tells the caller results are partial.
+	require.Error(t, err, "cancelled context must surface an error so callers know results are incomplete")
+	assert.ErrorIs(t, err, context.Canceled)
+}


### PR DESCRIPTION
## Problem

`runParallel` calls `queueJobs`, which exits early (without queuing all targets) when the caller's context is cancelled. The unqueued targets never run, so their slots in the `updated` slice keep their pre-attack (stale) values. Despite the incomplete results, `runParallel` returned `nil` error — callers had no way to know some targets were silently skipped.

## Fix

`queueJobs` now returns the count of targets it actually enqueued. If fewer than `len(targets)` were queued, `runParallel` wraps `ctx.Err()` and includes it in the returned error, matching the existing behaviour of surfacing per-target errors via `errors.Join`.

## Test

`TestRunParallel_CancelledContextSurfacesError` in `workers_test.go`:
- Cancels the context after the first job starts
- **Pre-fix**: `runParallel` returned `nil` error (test fails)
- **Post-fix**: returns a non-nil error wrapping `context.Canceled` (test passes)

Verified with `go test -race ./internal/attack/...`.