### PR TITLE
fix(dict): strip UTF-8 BOM from credentials JSON before unmarshaling

### DIFF
--- a/internal/dict/loader.go
+++ b/internal/dict/loader.go
@@ -2,6 +2,7 @@ package dict
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -109,6 +110,10 @@ func loadRoutes(routesPath string) (routes, error) {
 }
 
 func parseCredentials(content []byte) (credentials, error) {
+	// Strip a UTF-8 BOM written by some editors (e.g. Windows Notepad) so that
+	// json.Unmarshal does not fail with "invalid character" on an otherwise valid file.
+	content = bytes.TrimPrefix(content, []byte{0xEF, 0xBB, 0xBF})
+
 	if len(content) == 0 {
 		return credentials{}, errors.New("credentials dictionary is empty")
 	}

--- a/internal/dict/loader_test.go
+++ b/internal/dict/loader_test.go
@@ -240,6 +240,26 @@ func TestNew_CredentialsSanitization(t *testing.T) {
 	}
 }
 
+func TestNew_CredentialsBOMStripped(t *testing.T) {
+	// A UTF-8 BOM (0xEF 0xBB 0xBF) at the start of a credentials JSON file must be
+	// silently stripped before parsing, the same way parseRoutes strips BOM from the
+	// first route line.  Without the fix, json.Unmarshal sees a non-JSON prefix and
+	// returns "invalid character" — a confusing error for a valid file saved by
+	// Windows tools that write a BOM.
+	tempDir := t.TempDir()
+	routesPath := writeTempFile(t, tempDir, "routes", "stream\n")
+
+	bom := []byte{0xEF, 0xBB, 0xBF}
+	jsonBody := []byte(`{"usernames":["alice"],"passwords":["secret"]}`)
+	credsPath := filepath.Join(tempDir, "creds-bom.json")
+	require.NoError(t, os.WriteFile(credsPath, append(bom, jsonBody...), 0o600))
+
+	got, err := dict.New(credsPath, routesPath)
+	require.NoError(t, err, "credentials file with UTF-8 BOM should be accepted")
+	assert.Equal(t, []string{"alice"}, got.Usernames())
+	assert.Equal(t, []string{"secret"}, got.Passwords())
+}
+
 func writeTempFile(t *testing.T, dir, name, content string) string {
 	t.Helper()
 	path := filepath.Join(dir, name)


### PR DESCRIPTION
`parseRoutes` already strips a UTF-8 BOM from route lines via `strings.TrimPrefix`, but `parseCredentials` passes the raw bytes directly to `json.Unmarshal`. A BOM-prefixed credentials file (written by Windows Notepad and several other editors) therefore fails with `reading dictionary contents: invalid character 'ï' looking for beginning of value` even though the JSON is otherwise valid.

**Fix:** call `bytes.TrimPrefix(content, []byte{0xEF, 0xBB, 0xBF})` before the emptiness check and unmarshal, mirroring the existing BOM handling in `parseRoutes`.

**Test:** `TestNew_CredentialsBOMStripped` — writes a BOM-prefixed credentials file, asserts no error and correct values. Fails before the fix, passes after.