### PR TITLE
fix(skip): resolve hyphenated service names instead of rejecting as port ranges

### DIFF
--- a/internal/scan/skip/skip.go
+++ b/internal/scan/skip/skip.go
@@ -94,29 +94,8 @@ func parsePorts(ctx context.Context, ports []string) ([]uint16, error) {
 }
 
 func parsePortValue(ctx context.Context, value string) ([]uint16, error) {
-	if strings.Contains(value, "-") {
-		parts := strings.SplitN(value, "-", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid port range %q", value)
-		}
-
-		start, err := parsePortNumber(strings.TrimSpace(parts[0]))
-		if err != nil {
-			return nil, fmt.Errorf("invalid port range %q: %w", value, err)
-		}
-		end, err := parsePortNumber(strings.TrimSpace(parts[1]))
-		if err != nil {
-			return nil, fmt.Errorf("invalid port range %q: %w", value, err)
-		}
-		if start > end {
-			return nil, fmt.Errorf("invalid port range %q", value)
-		}
-
-		ports := make([]uint16, 0, int(end)-int(start)+1)
-		for p := int(start); p <= int(end); p++ {
-			ports = append(ports, uint16(p)) // #nosec G115 -- p is bounded to [1, 65535] by parsePortNumber
-		}
-		return ports, nil
+	if r, ok, err := tryParsePortRange(value); ok {
+		return r, err
 	}
 
 	port, err := parsePortNumber(value)
@@ -132,6 +111,36 @@ func parsePortValue(ctx context.Context, value string) ([]uint16, error) {
 		return nil, fmt.Errorf("port %d out of range", servicePort)
 	}
 	return []uint16{uint16(servicePort)}, nil
+}
+
+// tryParsePortRange attempts to parse value as a "start-end" numeric port range.
+// Returns (ports, true, err) when both sides look like port numbers; (nil, false, nil) otherwise.
+// When either side is not a valid port number the value is not a range (e.g. a
+// hyphenated service name like "http-alt"), so the caller falls through to LookupPort.
+func tryParsePortRange(value string) ([]uint16, bool, error) {
+	if !strings.Contains(value, "-") {
+		return nil, false, nil
+	}
+	parts := strings.SplitN(value, "-", 2)
+	start, ok1 := tryParsePortNumber(strings.TrimSpace(parts[0]))
+	end, ok2 := tryParsePortNumber(strings.TrimSpace(parts[1]))
+	if !ok1 || !ok2 {
+		return nil, false, nil
+	}
+	if start > end {
+		return nil, true, fmt.Errorf("invalid port range %q", value)
+	}
+	ports := make([]uint16, 0, int(end)-int(start)+1)
+	for p := int(start); p <= int(end); p++ {
+		ports = append(ports, uint16(p)) // #nosec G115 -- p is bounded to [1, 65535] by parsePortNumber
+	}
+	return ports, true, nil
+}
+
+// tryParsePortNumber is like parsePortNumber but reports success via a bool instead of an error.
+func tryParsePortNumber(value string) (uint16, bool) {
+	port, err := parsePortNumber(value)
+	return port, err == nil
 }
 
 func parsePortNumber(value string) (uint16, error) {

--- a/internal/scan/skip/skip.go
+++ b/internal/scan/skip/skip.go
@@ -98,8 +98,7 @@ func parsePortValue(ctx context.Context, value string) ([]uint16, error) {
 		return r, err
 	}
 
-	port, err := parsePortNumber(value)
-	if err == nil {
+	if port, ok := parsePortNumber(value); ok {
 		return []uint16{port}, nil
 	}
 
@@ -122,8 +121,8 @@ func tryParsePortRange(value string) ([]uint16, bool, error) {
 		return nil, false, nil
 	}
 	parts := strings.SplitN(value, "-", 2)
-	start, ok1 := tryParsePortNumber(strings.TrimSpace(parts[0]))
-	end, ok2 := tryParsePortNumber(strings.TrimSpace(parts[1]))
+	start, ok1 := parsePortNumber(strings.TrimSpace(parts[0]))
+	end, ok2 := parsePortNumber(strings.TrimSpace(parts[1]))
 	if !ok1 || !ok2 {
 		return nil, false, nil
 	}
@@ -137,21 +136,14 @@ func tryParsePortRange(value string) ([]uint16, bool, error) {
 	return ports, true, nil
 }
 
-// tryParsePortNumber is like parsePortNumber but reports success via a bool instead of an error.
-func tryParsePortNumber(value string) (uint16, bool) {
-	port, err := parsePortNumber(value)
-	return port, err == nil
-}
-
-func parsePortNumber(value string) (uint16, error) {
+// parsePortNumber parses value as a TCP port number in [1, 65535],
+// reporting success via a bool rather than an error.
+func parsePortNumber(value string) (uint16, bool) {
 	port, err := strconv.Atoi(value)
-	if err != nil {
-		return 0, err
+	if err != nil || port < 1 || port > 65535 {
+		return 0, false
 	}
-	if port < 1 || port > 65535 {
-		return 0, fmt.Errorf("port %d out of range", port)
-	}
-	return uint16(port), nil
+	return uint16(port), true
 }
 
 func expandTargets(ctx context.Context, targets []string) ([]netip.Addr, error) {

--- a/internal/scan/skip/skip_test.go
+++ b/internal/scan/skip/skip_test.go
@@ -97,6 +97,17 @@ func TestNew_ResolvesServicePorts(t *testing.T) {
 	assert.Equal(t, uint16(80), streams[0].Port)
 }
 
+func TestNew_ResolvesHyphenatedServicePortNames(t *testing.T) {
+	// Service names that contain a hyphen (e.g. "http-alt") must be resolved via
+	// LookupPort rather than rejected as malformed numeric ranges.
+	scanner := skip.New([]string{"127.0.0.1"}, []string{"http-alt"})
+
+	streams, err := scanner.Scan(t.Context())
+	require.NoError(t, err)
+	require.Len(t, streams, 1)
+	assert.Equal(t, uint16(8080), streams[0].Port)
+}
+
 func TestNew_ReturnsErrorOnUnknownServicePort(t *testing.T) {
 	scanner := skip.New([]string{"127.0.0.1"}, []string{"not-a-service"})
 


### PR DESCRIPTION
`parsePortValue` checked `strings.Contains(value, "-")` and entered numeric range parsing before ever attempting `LookupPort`. Any IANA service name containing a hyphen — `http-alt`, `ms-wbt-server`, `sip-tls`, `ms-sql-s`, etc. — failed with `invalid port range` because `strconv.Atoi` on the alphabetic half returned an error that was immediately propagated.

**Fix:** extract `tryParsePortRange` which only commits to the range path when *both* sides parse as valid port numbers. Non-numeric sides return `(nil, false, nil)`, letting `parsePortValue` fall through to `LookupPort` as intended.

**Test:** `TestNew_ResolvesHyphenatedServicePortNames` — fails on the old code (`invalid port "http-alt"`), passes after the fix.