### PR TITLE
fix(attack): scope fallback auth-scheme check to the method token only

### DIFF
--- a/internal/attack/detect_auth_test.go
+++ b/internal/attack/detect_auth_test.go
@@ -75,6 +75,20 @@ func TestAuthTypeFromHeaders(t *testing.T) {
 			values: base.HeaderValue{"Bearer abc"},
 			want:   cameradar.AuthUnknown,
 		},
+		{
+			// Unmarshal rejects a lower-case scheme ("basic" vs "Basic"), so the
+			// code falls back to a substring search on the raw header value.
+			// The realm contains "digest", which must NOT override the Basic scheme.
+			name:   "lowercase basic with digest in realm is still basic",
+			values: base.HeaderValue{`basic realm="digest-realm"`},
+			want:   cameradar.AuthBasic,
+		},
+		{
+			// Same as above for a lower-case "digest" scheme with "basic" in the realm.
+			name:   "lowercase digest with basic in realm is still digest",
+			values: base.HeaderValue{`digest realm="basic-realm", nonce="abc123"`},
+			want:   cameradar.AuthDigest,
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/attack/rtsp.go
+++ b/internal/attack/rtsp.go
@@ -182,9 +182,13 @@ func authTypeFromHeaders(values base.HeaderValue) cameradar.AuthType {
 		var authHeader headers.Authenticate
 		err := authHeader.Unmarshal(base.HeaderValue{value})
 		if err != nil {
+			// Extract only the scheme token (first word) to avoid false matches
+			// when realm or other parameters contain "basic" or "digest" as a
+			// substring (e.g. Basic realm="digest-cam").
 			lower := strings.ToLower(value)
-			hasDigest = hasDigest || strings.Contains(lower, "digest")
-			hasBasic = hasBasic || strings.Contains(lower, "basic")
+			scheme, _, _ := strings.Cut(lower, " ")
+			hasDigest = hasDigest || scheme == "digest"
+			hasBasic = hasBasic || scheme == "basic"
 			continue
 		}
 


### PR DESCRIPTION
When `gortsplib`'s `Authenticate.Unmarshal` rejects a non-canonical auth scheme
(e.g. a camera that sends `basic` or `digest` in lowercase), `authTypeFromHeaders`
falls back to a raw `strings.Contains` over the entire header value. A realm that
contains the word `"digest"` — e.g. `Basic realm="digest-cam"` — causes the
function to return `AuthDigest` instead of `AuthBasic`, so the attacker then tries
Digest credentials against a Basic-auth camera and fails to authenticate.

**Fix:** extract only the first whitespace-delimited token (the scheme) before
comparing, so that realm, nonce, and other parameters cannot influence the result.

A new test case reproduces the bug (`lowercase basic with digest in realm is still basic`): it fails on `master` and passes after this change.