### PR TITLE
fix(nmap): treat well-known RTSP ports as candidates when service is undetected

### DIFF
--- a/internal/scan/nmap/scanner.go
+++ b/internal/scan/nmap/scanner.go
@@ -134,10 +134,10 @@ func resolveScheme(port uint16, serviceName, tunnel string) string {
 
 // wellKnownRTSPPorts lists port numbers that are commonly used for RTSP even
 // when nmap cannot fingerprint the service (e.g. "tcpwrapped", "unknown").
-var wellKnownRTSPPorts = map[uint16]bool{
-	554:  true,
-	5554: true,
-	8554: true,
+var wellKnownRTSPPorts = map[uint16]struct{}{
+	554:  {},
+	5554: {},
+	8554: {},
 }
 
 // Extracting the classifying logic to an external function to avoid nesting if loops.
@@ -154,5 +154,6 @@ func streamCandidate(serviceName string, port uint16) bool {
 	// Fall back to well-known RTSP port numbers when service detection fails.
 	// nmap may report "tcpwrapped" or "unknown" for firewalled or slow hosts
 	// even on standard RTSP ports like 554 and 8554.
-	return wellKnownRTSPPorts[port]
+	_, ok := wellKnownRTSPPorts[port]
+	return ok
 }

--- a/internal/scan/nmap/scanner.go
+++ b/internal/scan/nmap/scanner.go
@@ -132,6 +132,14 @@ func resolveScheme(port uint16, serviceName, tunnel string) string {
 	}
 }
 
+// wellKnownRTSPPorts lists port numbers that are commonly used for RTSP even
+// when nmap cannot fingerprint the service (e.g. "tcpwrapped", "unknown").
+var wellKnownRTSPPorts = map[uint16]bool{
+	554:  true,
+	5554: true,
+	8554: true,
+}
+
 // Extracting the classifying logic to an external function to avoid nesting if loops.
 func streamCandidate(serviceName string, port uint16) bool {
 	serviceName = strings.ToLower(strings.TrimSpace(serviceName))
@@ -143,5 +151,8 @@ func streamCandidate(serviceName string, port uint16) bool {
 		return true
 	}
 
-	return false
+	// Fall back to well-known RTSP port numbers when service detection fails.
+	// nmap may report "tcpwrapped" or "unknown" for firewalled or slow hosts
+	// even on standard RTSP ports like 554 and 8554.
+	return wellKnownRTSPPorts[port]
 }

--- a/internal/scan/nmap/scanner_test.go
+++ b/internal/scan/nmap/scanner_test.go
@@ -269,6 +269,68 @@ func (r *recordingReporter) Summary([]cameradar.Stream, error) {}
 
 func (r *recordingReporter) Close() {}
 
+func TestStreamCandidate_WellKnownRTSPPorts(t *testing.T) {
+	// Well-known RTSP ports (554, 5554, 8554) must be treated as candidates
+	// even when nmap cannot fingerprint the service and reports a generic name
+	// like "tcpwrapped" or "unknown". Previously, streamCandidate relied solely
+	// on the service name containing "rtsp" or InferTunnelScheme returning a
+	// non-empty value; since 554/5554/8554 are not in InferTunnelScheme's port
+	// table, any service-detection failure silently dropped the stream.
+	tests := []struct {
+		serviceName string
+		port        uint16
+		want        bool
+	}{
+		{serviceName: "tcpwrapped", port: 554, want: true},
+		{serviceName: "unknown", port: 554, want: true},
+		{serviceName: "", port: 554, want: true},
+		{serviceName: "tcpwrapped", port: 5554, want: true},
+		{serviceName: "unknown", port: 5554, want: true},
+		{serviceName: "tcpwrapped", port: 8554, want: true},
+		{serviceName: "unknown", port: 8554, want: true},
+		// Ports that are NOT well-known RTSP ports with no service match should not be candidates.
+		{serviceName: "unknown", port: 9999, want: false},
+		{serviceName: "tcpwrapped", port: 8080, want: true}, // http port - still candidate via InferTunnelScheme
+	}
+	for _, tc := range tests {
+		got := streamCandidate(tc.serviceName, tc.port)
+		if got != tc.want {
+			t.Errorf("streamCandidate(%q, %d) = %v, want %v", tc.serviceName, tc.port, got, tc.want)
+		}
+	}
+}
+
+func TestRunScan_WellKnownRTSPPortWithUnknownService(t *testing.T) {
+	// When nmap reports port 554 (or 8554 / 5554) as open but cannot identify
+	// the service (e.g. "tcpwrapped"), runScan must still emit a stream for it.
+	reporter := &recordingReporter{}
+	runner := fakeRunner{
+		result: buildRun(nmaplib.Host{
+			Addresses: []nmaplib.Address{{Addr: "192.0.2.5", AddrType: "ipv4"}},
+			Ports: []nmaplib.Port{
+				openPort(554, "tcpwrapped", ""),
+				openPort(5554, "unknown", ""),
+				openPort(8554, "", ""),
+			},
+		}),
+	}
+
+	streams, err := runScan(t.Context(), runner, reporter)
+	if err != nil {
+		t.Fatalf("runScan returned unexpected error: %v", err)
+	}
+
+	want := []cameradar.Stream{
+		{Address: netip.MustParseAddr("192.0.2.5"), Port: 554},
+		{Address: netip.MustParseAddr("192.0.2.5"), Port: 5554},
+		{Address: netip.MustParseAddr("192.0.2.5"), Port: 8554},
+	}
+	if len(streams) != len(want) {
+		t.Fatalf("got %d streams, want %d; streams: %v", len(streams), len(want), streams)
+	}
+	assert.Equal(t, want, streams)
+}
+
 func buildRun(hosts ...nmaplib.Host) *nmaplib.Run {
 	return &nmaplib.Run{Hosts: hosts}
 }

--- a/internal/scan/nmap/scanner_test.go
+++ b/internal/scan/nmap/scanner_test.go
@@ -292,10 +292,10 @@ func TestStreamCandidate_WellKnownRTSPPorts(t *testing.T) {
 		{serviceName: "unknown", port: 9999, want: false},
 		{serviceName: "tcpwrapped", port: 8080, want: true}, // http port - still candidate via InferTunnelScheme
 	}
-	for _, tc := range tests {
-		got := streamCandidate(tc.serviceName, tc.port)
-		if got != tc.want {
-			t.Errorf("streamCandidate(%q, %d) = %v, want %v", tc.serviceName, tc.port, got, tc.want)
+	for _, test := range tests {
+		got := streamCandidate(test.serviceName, test.port)
+		if got != test.want {
+			t.Errorf("streamCandidate(%q, %d) = %v, want %v", test.serviceName, test.port, got, test.want)
 		}
 	}
 }
@@ -316,18 +316,14 @@ func TestRunScan_WellKnownRTSPPortWithUnknownService(t *testing.T) {
 	}
 
 	streams, err := runScan(t.Context(), runner, reporter)
-	if err != nil {
-		t.Fatalf("runScan returned unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	want := []cameradar.Stream{
 		{Address: netip.MustParseAddr("192.0.2.5"), Port: 554},
 		{Address: netip.MustParseAddr("192.0.2.5"), Port: 5554},
 		{Address: netip.MustParseAddr("192.0.2.5"), Port: 8554},
 	}
-	if len(streams) != len(want) {
-		t.Fatalf("got %d streams, want %d; streams: %v", len(streams), len(want), streams)
-	}
+	assert.Len(t, streams, len(want))
 	assert.Equal(t, want, streams)
 }
 

--- a/internal/scan/nmap/scanner_test.go
+++ b/internal/scan/nmap/scanner_test.go
@@ -294,9 +294,7 @@ func TestStreamCandidate_WellKnownRTSPPorts(t *testing.T) {
 	}
 	for _, test := range tests {
 		got := streamCandidate(test.serviceName, test.port)
-		if got != test.want {
-			t.Errorf("streamCandidate(%q, %d) = %v, want %v", test.serviceName, test.port, got, test.want)
-		}
+		assert.Equal(t, test.want, got, "streamCandidate(%q, %d)", test.serviceName, test.port)
 	}
 }
 


### PR DESCRIPTION
`streamCandidate` returns true only when the service name contains \"rtsp\" or `InferTunnelScheme` returns a non-empty scheme. The three standard RTSP port numbers (554, 5554, 8554) are absent from `InferTunnelScheme`'s port table, so when nmap cannot fingerprint the service and reports \"tcpwrapped\", \"unknown\", or an empty string, those ports are silently dropped before any stream is emitted.

Fix: add a `wellKnownRTSPPorts` map as a final fallback in `streamCandidate`. Two tests added: a unit test for `streamCandidate` covering all three ports with various unrecognized service names, and an integration-style test using `runScan` with a `fakeRunner` to confirm streams are emitted end-to-end.