### PR TITLE
fix(attack): skip credential attack when no route was found

### DIFF
--- a/internal/attack/attacker.go
+++ b/internal/attack/attacker.go
@@ -222,6 +222,10 @@ func updateSummary(reporter Reporter, streams []cameradar.Stream) {
 }
 
 func (a Attacker) attackCredentialsForStream(ctx context.Context, target cameradar.Stream) (cameradar.Stream, error) {
+	if !target.RouteFound {
+		return target, nil
+	}
+
 	for _, username := range a.dictionary.Usernames() {
 		for _, password := range a.dictionary.Passwords() {
 			if ctx.Err() != nil {

--- a/internal/attack/attacker_test.go
+++ b/internal/attack/attacker_test.go
@@ -221,6 +221,38 @@ func TestAttacker_Attack_ReturnsErrorWhenRouteMissing(t *testing.T) {
 	assert.False(t, got[0].RouteFound)
 }
 
+func TestAttacker_Attack_DoesNotSetCredentialsFoundWhenRouteNotFound(t *testing.T) {
+	// The server only accepts route "stream"; neither the dummy probe nor "missing"
+	// will match, so RouteFound stays false.  The credential phase must not mark
+	// CredentialsFound=true just because the server returns 404 (route not found)
+	// for the root path used when Routes is empty — 404 is not evidence of valid
+	// credentials when no route has been discovered.
+	addr, port := startRTSPServer(t, rtspServerConfig{
+		allowedRoute: "stream",
+		requireAuth:  false,
+		authMethod:   headers.AuthMethodBasic,
+	})
+
+	dict := testDictionary{
+		routes:    []string{"missing"},
+		usernames: []string{"user"},
+		passwords: []string{"pass"},
+	}
+
+	attacker, err := attack.New(dict, 0, time.Second, false, ui.NopReporter{})
+	require.NoError(t, err)
+
+	streams := []cameradar.Stream{{
+		Address: addr,
+		Port:    port,
+	}}
+
+	got, _ := attacker.Attack(t.Context(), streams)
+	require.Len(t, got, 1)
+	assert.False(t, got[0].RouteFound)
+	assert.False(t, got[0].CredentialsFound, "credential attack must not run when no route was found")
+}
+
 func TestAttacker_Attack_ReturnsErrorWhenCredentialsMissing(t *testing.T) {
 	addr, port := startRTSPServer(t, rtspServerConfig{
 		allowedRoute: "stream",


### PR DESCRIPTION
## Summary

`attackCredentialsForStream` was called even when `RouteFound` is false (no valid route discovered). With an empty `Routes` slice, `credAttack` probes `rtsp://host:port/` (the root path). A camera that has no matching route returns `404 Not Found` for every credential pair; because `credAttack` treats `404` as success in the inaccurate-protocol flow (valid creds, wrong route), `CredentialsFound` was incorrectly set to `true` and the returned stream carried a spurious username/password.

Fix: add an early return in `attackCredentialsForStream` when `!target.RouteFound`, keeping `CredentialsFound` false. The 401-masking camera flow is unaffected — those cameras return `401` during route discovery, which is treated as a route hit, so `RouteFound` is `true` before credential attack begins.

## Test plan

- New test `TestAttacker_Attack_DoesNotSetCredentialsFoundWhenRouteNotFound` fails before the fix and passes after.
- All existing tests continue to pass.