### PR TITLE
fix(ui): correct column-width overhead in clampColumns

### DIFF
--- a/internal/ui/clamp_test.go
+++ b/internal/ui/clamp_test.go
@@ -1,0 +1,35 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/stretchr/testify/assert"
+)
+
+// tableLineWidth returns the number of runes in the first line of rendered output.
+// Box-drawing characters (─, │, ┌, etc.) each occupy one terminal column.
+func tableLineWidth(rendered string) int {
+	line, _, _ := strings.Cut(rendered, "\n")
+	return len([]rune(line))
+}
+
+// TestSummaryColumnsClampedToTerminalWidth verifies that the plain-text summary
+// table produced by renderSummaryTablePlain never exceeds the requested terminal
+// width.  Prior to the fix, clampColumns underestimated the per-column rendering
+// overhead (2 instead of 3 chars, missing the leading '│'), so the table could
+// be up to len(columns)+1 = 9 characters wider than the terminal.
+func TestSummaryColumnsClampedToTerminalWidth(t *testing.T) {
+	// Width chosen so the table CAN fit after correct shrinkage, but
+	// overflows by 9 chars when the padding formula is wrong.
+	const terminalWidth = 145
+
+	rows := []table.Row{emptySummaryRow()}
+	columns := summaryColumns(terminalWidth, rows)
+	rendered := renderSummaryTablePlain(columns, rows)
+
+	lineWidth := tableLineWidth(rendered)
+	assert.LessOrEqual(t, lineWidth, terminalWidth,
+		"table is %d chars wide, exceeds terminal width %d", lineWidth, terminalWidth)
+}

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -603,7 +603,9 @@ func summaryColumns(width int, rows []table.Row) []table.Column {
 }
 
 func clampColumns(columns []table.Column, maxWidth int) []table.Column {
-	padding := 2 * len(columns)
+	// Each column renders as " " + value + " │" (3 chars overhead) plus the
+	// leading "│" for the whole row — so total overhead is 3*n+1, not 2*n.
+	padding := 3*len(columns) + 1
 	contentWidth := 0
 	for _, col := range columns {
 		contentWidth += col.Width
@@ -618,7 +620,7 @@ func clampColumns(columns []table.Column, maxWidth int) []table.Column {
 	minWidths := map[int]int{
 		7: 10,
 		3: 10,
-		4: 10,
+		4: 11, // "Credentials" title is 11 chars; never shrink below it
 		1: 10,
 	}
 	for over > 0 {


### PR DESCRIPTION
`clampColumns` used `padding = 2 * len(columns)` to estimate the rendered table width, but each column in `renderSummaryTablePlain` takes `width+3` chars (` ` + value + ` │`) plus a leading `│`, so the true overhead is `3*n+1`. With 8 columns this caused the table to be 9 chars wider than the terminal width after clamping.

The `minWidth` for the "Credentials" column (index 4) was also set to 10, one below its 11-char title, so `renderSummaryTablePlain` silently re-expanded it past the clamped target.

Fix: change `padding` to `3*len(columns)+1` and raise `minWidths[4]` to 11. A new unit test (`TestSummaryColumnsClampedToTerminalWidth`) fails before the patch and passes after.