### PR TITLE
feat: add attack-all-routes flag to probe every route

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,12 +323,16 @@ can increase attack duration.
 
 Example with Docker:
 
+Mount your custom routes list into the container and point `--custom-routes` at
+the in-container path:
+
 ```bash
 docker run --rm -t --net=host \
+        -v /path/to/dictionaries:/tmp/dictionaries \
         ullaakut/cameradar \
         --targets 192.168.1.0/24 \
         --ports "554,8554" \
-        --custom-routes ./my-routes \
+        --custom-routes /tmp/dictionaries/my_routes \
         --attack-all-routes
 ```
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,40 @@ FRAMECHECK=true \
         --ports "554,8554"
 ```
 
+### Try every route with `--attack-all-routes`
+
+Some cameras answer a request for a non-existent route with `401` or `403`
+instead of `404`. Cameradar reads that as "this device accepts any route", marks
+the default route as found, and stops before trying the rest of the dictionary.
+
+When you enable `--attack-all-routes`, Cameradar treats that default acceptance
+as a partial result and keeps attacking every route in the dictionary. This is
+mostly useful when you pass a custom routes list with `--custom-routes` and want
+each entry attempted regardless of how the camera answered the probe.
+
+`--attack-all-routes` is disabled by default because it adds RTSP requests and
+can increase attack duration.
+
+Example with Docker:
+
+```bash
+docker run --rm -t --net=host \
+        ullaakut/cameradar \
+        --targets 192.168.1.0/24 \
+        --ports "554,8554" \
+        --custom-routes ./my-routes \
+        --attack-all-routes
+```
+
+Example with local binary and environment variable:
+
+```bash
+ATTACK_ALL_ROUTES=true \
+        cameradar \
+        --targets 192.168.1.0/24 \
+        --ports "554,8554"
+```
+
 ## Security and responsible use
 
 Cameradar is a penetration testing tool.

--- a/cmd/cameradar/cameradar.go
+++ b/cmd/cameradar/cameradar.go
@@ -84,6 +84,7 @@ func runCameradar(ctx context.Context, cmd *cli.Command) error {
 			cmd.Duration(flagAttackInterval),
 			cmd.Duration(flagTimeout),
 			cmd.Bool(flagFrameCheck),
+			cmd.Bool(flagAttackAllRoutes),
 			cmd.Bool(flagSkipScan),
 			cmd.Bool(flagDebug),
 			resolvedMode,
@@ -110,7 +111,8 @@ func runCameradar(ctx context.Context, cmd *cli.Command) error {
 	interval := cmd.Duration(flagAttackInterval)
 	timeout := cmd.Duration(flagTimeout)
 	frameCheck := cmd.Bool(flagFrameCheck)
-	attacker, err := attack.New(dictionary, interval, timeout, frameCheck, reporter)
+	attackAllRoutes := cmd.Bool(flagAttackAllRoutes)
+	attacker, err := attack.New(dictionary, interval, timeout, frameCheck, attackAllRoutes, reporter)
 	if err != nil {
 		return fmt.Errorf("creating attacker: %w", err)
 	}
@@ -150,6 +152,7 @@ func buildStartupOptions(
 	attackInterval time.Duration,
 	timeout time.Duration,
 	frameCheck bool,
+	attackAllRoutes bool,
 	skipScan bool,
 	debug bool,
 	mode cameradar.Mode,
@@ -162,6 +165,7 @@ func buildStartupOptions(
 		"scanner: " + fallbackValue(scanner, "nmap"),
 		"scan-speed: " + strconv.FormatInt(int64(scanSpeed), 10),
 		"frame-check: " + strconv.FormatBool(frameCheck),
+		"attack-all-routes: " + strconv.FormatBool(attackAllRoutes),
 		"skip-scan: " + strconv.FormatBool(skipScan),
 		"attack-interval: " + attackInterval.String(),
 		"timeout: " + timeout.String(),

--- a/cmd/cameradar/main.go
+++ b/cmd/cameradar/main.go
@@ -25,6 +25,7 @@ const (
 	flagAttackInterval    = "attack-interval"
 	flagTimeout           = "timeout"
 	flagFrameCheck        = "framecheck"
+	flagAttackAllRoutes   = "attack-all-routes"
 	flagSkipScan          = "skip-scan"
 	flagDebug             = "debug"
 	flagUI                = "ui"
@@ -94,6 +95,12 @@ var flags = cmd.Flags{
 		Name:    flagFrameCheck,
 		Usage:   "When DESCRIBE returns 200 OK, require a frame probe check before accepting routes or credentials (slower)",
 		Sources: cli.EnvVars(strcase.ToSNAKE(flagFrameCheck)),
+		Value:   false,
+	},
+	&cli.BoolFlag{
+		Name:    flagAttackAllRoutes,
+		Usage:   "Keep attacking every route in the dictionary instead of stopping once a camera accepts the default route (useful with a custom routes dictionary)",
+		Sources: cli.EnvVars(strcase.ToSNAKE(flagAttackAllRoutes)),
 		Value:   false,
 	},
 	&cli.BoolFlag{

--- a/internal/attack/attacker.go
+++ b/internal/attack/attacker.go
@@ -39,25 +39,27 @@ type Reporter interface {
 
 // Attacker attempts to discover routes and credentials for RTSP streams.
 type Attacker struct {
-	dictionary     Dictionary
-	reporter       Reporter
-	attackInterval time.Duration
-	timeout        time.Duration
-	framecheck     bool
+	dictionary      Dictionary
+	reporter        Reporter
+	attackInterval  time.Duration
+	timeout         time.Duration
+	framecheck      bool
+	attackAllRoutes bool
 }
 
 // New builds an Attacker with the provided dependencies.
-func New(dict Dictionary, attackInterval, timeout time.Duration, framecheck bool, reporter Reporter) (Attacker, error) {
+func New(dict Dictionary, attackInterval, timeout time.Duration, framecheck, attackAllRoutes bool, reporter Reporter) (Attacker, error) {
 	if dict == nil {
 		return Attacker{}, errors.New("dictionary is required")
 	}
 
 	return Attacker{
-		dictionary:     dict,
-		attackInterval: attackInterval,
-		timeout:        timeout,
-		framecheck:     framecheck,
-		reporter:       reporter,
+		dictionary:      dict,
+		attackInterval:  attackInterval,
+		timeout:         timeout,
+		framecheck:      framecheck,
+		attackAllRoutes: attackAllRoutes,
+		reporter:        reporter,
 	}, nil
 }
 
@@ -274,7 +276,13 @@ func (a Attacker) attackRoutesForStream(ctx context.Context, target cameradar.St
 		target.RouteFound = true
 		target.Routes = append(target.Routes, "") // Add empty route for default.
 		a.reporter.Progress(cameradar.StepAttackRoutes, fmt.Sprintf("Default route accepted for %s:%d", target.Address.String(), target.Port))
-		return target, nil
+		// A camera that answers the probe route with 401 or 403 instead of 404
+		// looks like it accepts any route, so we normally stop here. When
+		// attackAllRoutes is set we treat that as a partial result and keep
+		// probing the dictionary, which matters with a custom routes list.
+		if !a.attackAllRoutes {
+			return target, nil
+		}
 	}
 
 	for _, route := range a.dictionary.Routes() {

--- a/internal/attack/attacker_test.go
+++ b/internal/attack/attacker_test.go
@@ -41,7 +41,7 @@ func TestNew(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			attacker, err := attack.New(test.dict, 10*time.Millisecond, time.Second, false, ui.NopReporter{})
+			attacker, err := attack.New(test.dict, 10*time.Millisecond, time.Second, false, false, ui.NopReporter{})
 			test.wantErr(t, err)
 			if err != nil {
 				assert.NotNil(t, attacker)
@@ -67,7 +67,7 @@ func TestAttacker_Attack_BasicAuth(t *testing.T) {
 
 	testInterval := time.Millisecond
 	testRequestTimeout := time.Second
-	attacker, err := attack.New(dict, testInterval, testRequestTimeout, false, ui.NopReporter{})
+	attacker, err := attack.New(dict, testInterval, testRequestTimeout, false, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -86,6 +86,56 @@ func TestAttacker_Attack_BasicAuth(t *testing.T) {
 	assert.Equal(t, "user", got[0].Username)
 	assert.Equal(t, "pass", got[0].Password)
 	assert.Contains(t, got[0].Routes, "stream")
+}
+
+func TestAttacker_Attack_AttackAllRoutes(t *testing.T) {
+	// This server answers every DESCRIBE with 401 (like a camera that returns
+	// something other than 404 on a non-existent route), so the probe route is
+	// accepted and Cameradar would normally stop before trying the dictionary.
+	newServer := func(t *testing.T) (netip.Addr, uint16) {
+		return startRTSPServer(t, rtspServerConfig{
+			allowAll:    true,
+			requireAuth: true,
+			username:    "user",
+			password:    "pass",
+			authMethod:  headers.AuthMethodDigest,
+			sendFrames:  true,
+		})
+	}
+
+	dict := testDictionary{
+		routes:    []string{"stream"},
+		usernames: []string{"user"},
+		passwords: []string{"pass"},
+	}
+
+	t.Run("disabled stops at the default route", func(t *testing.T) {
+		addr, port := newServer(t)
+
+		attacker, err := attack.New(dict, 0, time.Second, false, false, ui.NopReporter{})
+		require.NoError(t, err)
+
+		got, err := attacker.Attack(t.Context(), []cameradar.Stream{{Address: addr, Port: port}})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+
+		assert.True(t, got[0].RouteFound)
+		assert.NotContains(t, got[0].Routes, "stream")
+	})
+
+	t.Run("enabled keeps attacking the dictionary", func(t *testing.T) {
+		addr, port := newServer(t)
+
+		attacker, err := attack.New(dict, 0, time.Second, false, true, ui.NopReporter{})
+		require.NoError(t, err)
+
+		got, err := attacker.Attack(t.Context(), []cameradar.Stream{{Address: addr, Port: port}})
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+
+		assert.True(t, got[0].RouteFound)
+		assert.Contains(t, got[0].Routes, "stream")
+	})
 }
 
 func TestAttacker_Attack_AuthVariants(t *testing.T) {
@@ -142,7 +192,7 @@ func TestAttacker_Attack_AuthVariants(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			addr, port := startRTSPServer(t, test.config)
 
-			attacker, err := attack.New(test.dict, 0, time.Second, false, ui.NopReporter{})
+			attacker, err := attack.New(test.dict, 0, time.Second, false, false, ui.NopReporter{})
 			require.NoError(t, err)
 
 			streams := []cameradar.Stream{{
@@ -167,7 +217,7 @@ func TestAttacker_Attack_AuthVariants(t *testing.T) {
 }
 
 func TestAttacker_Attack_ValidationErrors(t *testing.T) {
-	attacker, err := attack.New(testDictionary{routes: []string{"stream"}}, 0, time.Second, false, ui.NopReporter{})
+	attacker, err := attack.New(testDictionary{routes: []string{"stream"}}, 0, time.Second, false, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -206,7 +256,7 @@ func TestAttacker_Attack_ReturnsErrorWhenRouteMissing(t *testing.T) {
 		passwords: []string{"pass"},
 	}
 
-	attacker, err := attack.New(dict, 0, time.Second, false, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, time.Second, false, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -236,7 +286,7 @@ func TestAttacker_Attack_ReturnsErrorWhenCredentialsMissing(t *testing.T) {
 		passwords: []string{"wrong"},
 	}
 
-	attacker, err := attack.New(dict, 0, time.Second, false, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, time.Second, false, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -270,7 +320,7 @@ func TestAttacker_Attack_CredentialAttemptFails(t *testing.T) {
 		passwords: []string{"pass"},
 	}
 
-	attacker, err := attack.New(dict, 0, time.Second, false, reporter)
+	attacker, err := attack.New(dict, 0, time.Second, false, false, reporter)
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -298,7 +348,7 @@ func TestAttacker_Attack_UnreachableHostDoesNotDropOthers(t *testing.T) {
 		routes: []string{"stream"},
 	}
 
-	attacker, err := attack.New(dict, 0, 200*time.Millisecond, false, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, 200*time.Millisecond, false, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	// The unreachable host is listed first so that, before the fix, its
@@ -337,7 +387,7 @@ func TestAttacker_Attack_AggregatesErrorsFromMultipleHosts(t *testing.T) {
 		routes: []string{"stream"},
 	}
 
-	attacker, err := attack.New(dict, 0, 200*time.Millisecond, false, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, 200*time.Millisecond, false, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{
@@ -391,7 +441,7 @@ func TestAttacker_Attack_AllowsDummyRoute(t *testing.T) {
 
 	dict := testDictionary{}
 
-	attacker, err := attack.New(dict, 0, time.Second, false, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, time.Second, false, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -419,7 +469,7 @@ func TestAttacker_Attack_ValidationFailsWhenSetupErrors(t *testing.T) {
 		routes: []string{"stream"},
 	}
 
-	attacker, err := attack.New(dict, 0, time.Second, false, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, time.Second, false, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -447,7 +497,7 @@ func TestAttacker_Attack_Framecheck_RechecksRouteFalsePositives(t *testing.T) {
 		routes: []string{"stream"},
 	}
 
-	attacker, err := attack.New(dict, 0, 500*time.Millisecond, true, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, 500*time.Millisecond, true, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -481,7 +531,7 @@ func TestAttacker_Attack_Framecheck_RechecksCredentialFalsePositives(t *testing.
 		passwords: []string{"wrong", "pass"},
 	}
 
-	attacker, err := attack.New(dict, 0, 500*time.Millisecond, true, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, 500*time.Millisecond, true, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -515,7 +565,7 @@ func TestAttacker_Attack_Framecheck_FallsBackToTCPForRouteProbe(t *testing.T) {
 		routes: []string{"stream"},
 	}
 
-	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, reporter)
+	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, false, reporter)
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -551,7 +601,7 @@ func TestAttacker_Attack_Framecheck_FallsBackToTCPForCredentialProbe(t *testing.
 		passwords: []string{"wrong", "pass"},
 	}
 
-	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, ui.NopReporter{})
+	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -585,7 +635,7 @@ func TestAttacker_Attack_Framecheck_TreatsNoPacketAsFalsePositive(t *testing.T) 
 		routes: []string{"stream"},
 	}
 
-	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, reporter)
+	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, false, reporter)
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -619,7 +669,7 @@ func TestAttacker_Attack_Framecheck_TreatsNoMediasAsFalsePositive(t *testing.T) 
 
 	dict := testDictionary{}
 
-	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, reporter)
+	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, false, reporter)
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{
@@ -655,7 +705,7 @@ func TestAttacker_Attack_Framecheck_LogsDescribeRetryWithCurrentStep(t *testing.
 
 	dict := testDictionary{}
 
-	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, reporter)
+	attacker, err := attack.New(dict, 0, 100*time.Millisecond, true, false, reporter)
 	require.NoError(t, err)
 
 	streams := []cameradar.Stream{{

--- a/internal/attack/attacker_test.go
+++ b/internal/attack/attacker_test.go
@@ -89,20 +89,6 @@ func TestAttacker_Attack_BasicAuth(t *testing.T) {
 }
 
 func TestAttacker_Attack_AttackAllRoutes(t *testing.T) {
-	// This server answers every DESCRIBE with 401 (like a camera that returns
-	// something other than 404 on a non-existent route), so the probe route is
-	// accepted and Cameradar would normally stop before trying the dictionary.
-	newServer := func(t *testing.T) (netip.Addr, uint16) {
-		return startRTSPServer(t, rtspServerConfig{
-			allowAll:    true,
-			requireAuth: true,
-			username:    "user",
-			password:    "pass",
-			authMethod:  headers.AuthMethodDigest,
-			sendFrames:  true,
-		})
-	}
-
 	dict := testDictionary{
 		routes:    []string{"stream"},
 		usernames: []string{"user"},
@@ -110,7 +96,7 @@ func TestAttacker_Attack_AttackAllRoutes(t *testing.T) {
 	}
 
 	t.Run("disabled stops at the default route", func(t *testing.T) {
-		addr, port := newServer(t)
+		addr, port := startAllRoutesServer(t)
 
 		attacker, err := attack.New(dict, 0, time.Second, false, false, ui.NopReporter{})
 		require.NoError(t, err)
@@ -124,7 +110,7 @@ func TestAttacker_Attack_AttackAllRoutes(t *testing.T) {
 	})
 
 	t.Run("enabled keeps attacking the dictionary", func(t *testing.T) {
-		addr, port := newServer(t)
+		addr, port := startAllRoutesServer(t)
 
 		attacker, err := attack.New(dict, 0, time.Second, false, true, ui.NopReporter{})
 		require.NoError(t, err)

--- a/internal/attack/detect_auth_test.go
+++ b/internal/attack/detect_auth_test.go
@@ -190,7 +190,7 @@ func TestDetectAuthMethod(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			addr, port := startRTSPProbeServer(t, test.statusCode, test.headers)
 
-			attacker, err := New(testDictionary{}, 0, time.Second, false, ui.NopReporter{})
+			attacker, err := New(testDictionary{}, 0, time.Second, false, false, ui.NopReporter{})
 			require.NoError(t, err)
 
 			stream := cameradar.Stream{
@@ -216,7 +216,7 @@ func TestDetectAuthMethod_HTTPTunnel_NonFatal(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			attacker, err := New(testDictionary{}, 0, time.Second, false, ui.NopReporter{})
+			attacker, err := New(testDictionary{}, 0, time.Second, false, false, ui.NopReporter{})
 			require.NoError(t, err)
 
 			stream := cameradar.Stream{
@@ -237,7 +237,7 @@ func TestDetectAuthMethod_RTSPS(t *testing.T) {
 		"WWW-Authenticate": headers.Authenticate{Method: headers.AuthMethodBasic, Realm: "cam"}.Marshal(),
 	})
 
-	attacker, err := New(testDictionary{}, 0, time.Second, false, ui.NopReporter{})
+	attacker, err := New(testDictionary{}, 0, time.Second, false, false, ui.NopReporter{})
 	require.NoError(t, err)
 
 	stream := cameradar.Stream{

--- a/internal/attack/rtsp_test.go
+++ b/internal/attack/rtsp_test.go
@@ -318,3 +318,22 @@ func authMethods(method headers.AuthMethod) []auth.VerifyMethod {
 		return nil
 	}
 }
+
+// startAllRoutesServer starts an RTSP server that accepts any route. On an
+// unauthenticated DESCRIBE (the route-probing phase) it answers 401 rather than
+// 404 for unknown routes, like a camera that does not 404 on non-existent
+// routes; once valid credentials are supplied it returns 200. This makes the
+// probe route look valid, so Cameradar would normally stop before trying the
+// dictionary.
+func startAllRoutesServer(t *testing.T) (netip.Addr, uint16) {
+	t.Helper()
+
+	return startRTSPServer(t, rtspServerConfig{
+		allowAll:    true,
+		requireAuth: true,
+		username:    "user",
+		password:    "pass",
+		authMethod:  headers.AuthMethodDigest,
+		sendFrames:  true,
+	})
+}


### PR DESCRIPTION
Closes #483.

This picks up the suggestion from #481: when a camera answers a request for a bogus route with 401 or 403 instead of 404, Cameradar concludes it accepts any route, marks the default route as found, and stops before trying the dictionary. On those cameras the real routes in a custom list never get attacked.

This adds an opt-in `--attack-all-routes` flag (env `ATTACK_ALL_ROUTES`). When set, the default acceptance is treated as a partial result and Cameradar keeps probing every route in the dictionary. It is off by default so nothing changes for existing users.

Wired through the same way as `--framecheck`: a bool on the attacker, a CLI flag, and a line in the startup summary. Added a test that fails without the change (the dictionary route is never recorded) and passes with it, plus a short README section.

`make test` and the linter pass locally.
